### PR TITLE
Make circuit-notation plugin usable

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -xeou pipefail
 
-cabal haddock --enable-documentation clash-protocols |& tee haddock_log
+# circuit-notation currently _compiles on 8.10, but isn't usable. The only
+# other GHC version it supports is 8.6.5, but this GHC bundles a Haddock that
+# cannot generate documentation for clash-prelude. Hence, we build docs with
+# 8.10 and relax circuit-notation's ghc bounds
+cabal haddock \
+  --enable-documentation \
+  --allow-newer=circuit-notation:ghc \
+  clash-protocols \
+  |& tee haddock_log
 
 set +e
 if grep -q "Missing documentation" haddock_log; then

--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:focal
+ARG GHC_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/bin:/root/.ghcup/bin:$PATH
 
@@ -6,7 +7,6 @@ ENV LATEST_STACK=linux-x86_64.tar.gz
 ENV STACK_DEPS="g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg netbase"
 ARG GHC_DEPS="curl libc6-dev libgmp-dev pkg-config libnuma-dev build-essential"
 
-ENV GHC_VERSION=8.10.2
 ENV CABAL_VERSION=3.2.0.0
 
 ARG GHCUP_URL="https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup"

--- a/.ci/docker/build-and-publish-docker-image.sh
+++ b/.ci/docker/build-and-publish-docker-image.sh
@@ -3,18 +3,22 @@
 set -xeo pipefail
 
 REPO="docker.pkg.github.com/clash-lang/clash-protocols"
-NAME="focal-ghc-cabal-stack"
 DIR=$(dirname "$0")
 now=$(date +%F)
 
-docker build -t "${REPO}/${NAME}:$now" "$DIR"
-docker tag "${REPO}/${NAME}:$now" "${REPO}/${NAME}:latest"
+for GHC_VERSION in "8.6.5" "8.10.2"
+do
+  NAME="protocols-focal-ghc-cabal-stack-${GHC_VERSION}"
 
-read -p "Push to GitHub? (y/N) " push
+  docker build -t "${REPO}/${NAME}:$now" "$DIR" --build-arg GHC_VERSION=${GHC_VERSION}
+  docker tag "${REPO}/${NAME}:$now" "${REPO}/${NAME}:latest"
 
-if [[ $push =~ ^[Yy]$ ]]; then
-        docker push "${REPO}/${NAME}:$now"
-        docker push "${REPO}/${NAME}:latest"
-else
-        echo "Skipping push to container registry"
-fi
+  read -p "Push to GitHub? (y/N) " push
+
+  if [[ $push =~ ^[Yy]$ ]]; then
+          docker push "${REPO}/${NAME}:$now"
+          docker push "${REPO}/${NAME}:latest"
+  else
+          echo "Skipping push to container registry"
+  fi
+done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 .common:
-  image: docker.pkg.github.com/clash-lang/stack-templates/focal-ghc-cabal-stack:2020-11-28
   timeout: 1 hour
   retry:
     max: 2
@@ -21,12 +20,21 @@
   after_script:
     - tar -cf - $(ls -d /root/.cabal /root/.stack /nix || true) | zstd -T0 -3 > cache.tar.zstd
 
+.common-806:
+  extends: .common
+  image: docker.pkg.github.com/clash-lang/clash-protocols/protocols-focal-ghc-cabal-stack-8.6.5:2020-12-07
+  variables:
+    GHC_VERSION: "8.6.5"
+    CABAL_VERSION: "3.2.0.0"
+
 .common-810:
   extends: .common
+  image: docker.pkg.github.com/clash-lang/clash-protocols/protocols-focal-ghc-cabal-stack-8.10.2:2020-12-07
   variables:
     GHC_VERSION: "8.10.2"
     CABAL_VERSION: "3.2.0.0"
 
+# Haddock is broken on 865.
 haddock:
   extends: .common-810
   artifacts:
@@ -36,12 +44,14 @@ haddock:
   script:
     - .ci/build_docs.sh
 
-cabal-8.10.2:
-  extends: .common-810
+# Circuit-notation is broken on 810.
+# https://github.com/cchalmers/circuit-notation/pull/8#issuecomment-739844352
+cabal-8.6.5:
+  extends: .common-806
   script:
     - .ci/test_cabal.sh
 
 stack:
-  extends: .common
+  extends: .common-806
   script:
     - .ci/test_stack.sh

--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -1,4 +1,4 @@
-cabal-version:       3.0
+cabal-version:       2.4
 name:                clash-protocols
 synopsis:            a battery-included library for performant dataflow protocols
 Homepage:            https://gitlab.com/martijnbastiaan/clash-protocols
@@ -79,12 +79,12 @@ common common-options
 
   default-language: Haskell2010
   build-depends:
-    -- GHC >= 8.8
-    base >= 4.13.0.0,
+    -- GHC >= 8.6
+    base >= 4.12.0.0,
     Cabal,
 
     -- clash-prelude will set suitable version bounds for the plugins
-    clash-prelude >= 1.2.2 && < 1.4,
+    clash-prelude >= 1.2.5 && < 1.4,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat
@@ -117,7 +117,7 @@ library
     , extra
     , data-default
     , hedgehog >= 1.0.3
-    , ghc >= 8.10
+    , ghc >= 8.6
     , pretty-show
 
   exposed-modules:
@@ -127,6 +127,9 @@ library
     Protocols.Df.Simple
     Protocols.Hedgehog
     Protocols.Plugin
+
+  other-modules:
+    Data.Bifunctor.Extra
 
   default-language: Haskell2010
 

--- a/src/Data/Bifunctor/Extra.hs
+++ b/src/Data/Bifunctor/Extra.hs
@@ -1,0 +1,12 @@
+module Data.Bifunctor.Extra where
+
+import Data.Bifunctor (bimap)
+import Data.Tuple (swap)
+
+-- | Same as 'Data.Bifunctor.bimap', but:
+--
+--   * Specialized on (,)
+--   * Swaps elements of resulting tuple
+--
+swapMap :: (a -> b) -> (c -> d) -> (a, c) -> (d, b)
+swapMap f g = swap . bimap f g

--- a/src/Protocols/DfLike.hs
+++ b/src/Protocols/DfLike.hs
@@ -318,7 +318,7 @@ mealy ::
   -- | Transition function
   ( s ->
     (Maybe (Meta a, Payload a), Protocols.Ack) ->
-    (s, (Maybe (Meta b, Payload b), Protocols.Ack)) ) ->
+    (s, (Protocols.Ack, Maybe (Meta b, Payload b))) ) ->
   -- | Initial state
   s ->
   -- | Circuit analogous to mealy machine

--- a/src/Protocols/Plugin.hs
+++ b/src/Protocols/Plugin.hs
@@ -19,14 +19,14 @@ import qualified CircuitNotation as CN
 import qualified GhcPlugins as GHC
 
 -- | Type inference helper used by circuit-notation plugin
-type ProtocolT a b = (Fwd a, Bwd b) -> (Fwd b, Bwd a)
+type CircuitT a b = (Fwd a, Bwd b) -> (Bwd a, Fwd b)
 
 -- | 'circuit-notation' plugin repurposed for 'Protocols.protocols'.
 plugin :: GHC.Plugin
 plugin = CN.mkPlugin $ CN.ExternalNames
   { CN.circuitCon = CN.thName 'Circuit
   , CN.circuitTyCon = CN.thName ''Circuit
-  , CN.circuitTTyCon = CN.thName ''ProtocolT
-  , CN.runCircuitName = CN.thName 'fromSignals
+  , CN.circuitTTyCon = CN.thName ''CircuitT
+  , CN.runCircuitName = CN.thName 'toSignals
   , CN.fwdBwdCon = CN.thName '(,)
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,11 @@
-resolver: nightly-2020-12-02
+resolver: lts-14.27
+
+extra-deps:
+- ghc-typelits-extra-0.4@sha256:e1ba4ebf14cb7025dd940380dfb15db444f7e8bced7e30bdad6e1707f0af7622,4813
+- ghc-typelits-knownnat-0.7.2@sha256:63054c8108f21a4bc5ace477227476b72a4e3792f35f37f2d406eef262ae4346,4711
+- ghc-typelits-natnormalise-0.7.2@sha256:0fc48a3744aa25e5e53a054a8bb1fe6410752e497f446d75db9bd67bb258d05e,3495
+- hedgehog-1.0.3@sha256:dd9a25bf904fe444d5de471d0933261ef2c9a1110330460e037e0fef86fac89e,4622
+- clash-prelude-1.2.5@sha256:2ea4d0506adfccd0e817a67e47de132290a856535dd69bcc71e7fbce24ece3f2,15307
 
 flags:
   clash-prelude:

--- a/tests/Tests/Protocols/Plugin.hs
+++ b/tests/Tests/Protocols/Plugin.hs
@@ -14,8 +14,8 @@ module Tests.Protocols.Plugin where
 import qualified Clash.Prelude as C
 
 import           Protocols
--- import           Protocols.Df.Simple (Dfs)
--- import qualified Protocols.Df.Simple as Dfs
+import           Protocols.Df.Simple (Dfs)
+import qualified Protocols.Df.Simple as Dfs
 
 swapC :: Circuit (a, b) (b, a)
 swapC = circuit $ \(a, b) -> (b, a)
@@ -23,8 +23,10 @@ swapC = circuit $ \(a, b) -> (b, a)
 unvecC :: Circuit (C.Vec 2 a) (a, a)
 unvecC = circuit \[x,y] -> (x, y)
 
--- registerBoth :: Circuit (Dfs dom a, Dfs dom b) (Dfs dom a, Dfs dom b)
--- registerBoth = circuit $ \(a, b) -> do
---   a' <- Dfs.registerFwd -< a
---   b' <- Dfs.registerFwd -< b
---   idC -< (a', b')
+registerBoth ::
+  (C.NFDataX a, C.NFDataX b, C.KnownDomain dom, C.HiddenClockResetEnable dom) =>
+  Circuit (Dfs dom a, Dfs dom b) (Dfs dom a, Dfs dom b)
+registerBoth = circuit $ \(a, b) -> do
+  a' <- Dfs.registerFwd -< a
+  b' <- Dfs.registerFwd -< b
+  idC -< (a', b')


### PR DESCRIPTION
That meant:

 * swapping the elements of the result of the circuit function
 * downgrading to GHC 8.6, as support for 8.10 is still in the works
 * downgrading to Cabal 2.4, to satisfy GHC 8.6

Fixes #2.