### PR TITLE
Fix deprecated testProperty

### DIFF
--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -134,7 +134,7 @@ library
 
       -- To be removed; we need 'Test.Tasty.Hedgehog.Extra' to fix upstream issues
     , tasty >= 1.2 && < 1.5
-    , tasty-hedgehog
+    , tasty-hedgehog >= 1.2
 
   exposed-modules:
     Protocols
@@ -187,7 +187,7 @@ test-suite unittests
     hashable,
     hedgehog,
     tasty >= 1.2 && < 1.5,
-    tasty-hedgehog,
+    tasty-hedgehog >= 1.2,
     tasty-th
 
 test-suite doctests

--- a/src/Test/Tasty/Hedgehog/Extra.hs
+++ b/src/Test/Tasty/Hedgehog/Extra.hs
@@ -9,7 +9,11 @@ import Prelude
 import Hedgehog (Property)
 import qualified Test.Tasty.Hedgehog as H
 import Test.Tasty (TestTree)
+import Data.String
 
 -- | Like 'Test.Tasty.Hedgehog.testProperty', but inserts correct name
 testProperty :: [Char] -> Property -> TestTree
-testProperty nm = H.testProperty ("prop_" <> nm)
+testProperty nm = H.testPropertyNamed testName propName
+  where
+    testName = fromString $ "prop " <> nm
+    propName = fromString $ "prop_" <> nm

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,3 +10,4 @@ extra-deps:
     - hedgehog
 - git: https://github.com/cchalmers/circuit-notation.git
   commit: 2574640364eef12222517af059b9e4a7e6b503a7
+- tasty-hedgehog-1.2.0.0


### PR DESCRIPTION
`testProperty` is deprecated, replace it by `testPropertyNamed`.