### PR TITLE
AXI4 Refactor

### DIFF
--- a/src/Protocols/Axi4/Common.hs
+++ b/src/Protocols/Axi4/Common.hs
@@ -2,141 +2,89 @@
 Types and utilities shared between AXI4, AXI4-Lite, and AXI3.
 -}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Protocols.Axi4.Common where
 
 -- base
-import Data.Kind (Type)
 import GHC.Generics (Generic)
 import GHC.TypeNats (Nat)
 
 -- clash-prelude
 import qualified Clash.Prelude as C
-import Clash.Prelude (type (^), type (-), type (*))
+import Clash.Prelude (type (^), type (-))
 
 -- strict-tuple
 import Data.Tuple.Strict (T3, T4)
 
--- | Simple wrapper to achieve "named arguments" when instantiating an AXI protocol
-data IdWidth = IdWidth Nat
-
--- | Simple wrapper to achieve "named arguments" when instantiating an AXI protocol
-data AddrWidth = AddrWidth Nat
-
--- | Simple wrapper to achieve "named arguments" when instantiating an AXI protocol
-data LengthWidth = LengthWidth Nat
-
--- | Simple wrapper to achieve "named arguments" when instantiating an AXI protocol
-data UserType = UserType Type KeepStrobe
-
--- | Keep or remove Burst, see 'BurstMode'
-data KeepBurst = KeepBurst | NoBurst
-
--- | Keep or remove Burst Length, see 'BurstSize'
-data KeepBurstLength = KeepBurstLength | NoBurstLength
-
--- | Keep or remove cache field, see 'Cache'
-data KeepCache = KeepCache | NoCache
-
--- | Keep or remove last field
-data KeepLast = KeepLast | NoLast
-
--- | Keep or remove lock, see 'AtomicAccess'
-data KeepLock = KeepLock | NoLock
-
--- | Keep or remove permissions, see 'Privileged', 'Secure', and
--- 'InstructionOrData'.
-data KeepPermissions = KeepPermissions | NoPermissions
-
--- | Keep or remove quality of service field. See 'Qos'.
-data KeepQos = KeepQos | NoQos
-
--- | Keep or remove region field
-data KeepRegion = KeepRegion | NoRegion
-
--- | Keep or remove response field. See 'Resp'.
-data KeepResponse = KeepResponse | NoResponse
-
--- | Keep or remove burst size field. See 'BurstSize'.
-data KeepSize = KeepSize | NoSize
-
--- | Keep or remove strobe field. See 'Strobe'
-data KeepStrobe = KeepStrobe | NoStrobe
-
--- | Type used to introduce strobe information on the term level
-data SKeepStrobe (strobeType :: KeepStrobe) where
-  SKeepStrobe :: SKeepStrobe 'KeepStrobe
-  SNoStrobe :: SKeepStrobe 'NoStrobe
-
--- | Extracts Nat from 'IdWidth', 'AddrWidth', and 'LengthWidth'
-type family Width (a :: k) :: Nat where
-  Width ('IdWidth n) = n
-  Width ('AddrWidth n) = n
-  Width ('LengthWidth n) = n
+import Protocols.Internal
 
 -- | Enables or disables 'BurstMode'
-type family BurstType (keepBurst :: KeepBurst) where
-  BurstType 'KeepBurst = BurstMode
-  BurstType 'NoBurst = ()
+type BurstType (keep :: Bool) = KeepType keep BurstMode
 
 -- | Enables or disables burst length
-type family BurstLengthType (keepBurstLength :: KeepBurstLength) where
-  BurstLengthType 'KeepBurstLength = C.Index (2^8)
-  BurstLengthType 'NoBurstLength = ()
+type BurstLengthType (keep :: Bool) = KeepType keep (C.Index (2^8))
 
 -- | Enables or disables 'Cache'
-type family CacheType (keepCache :: KeepCache) where
-  CacheType 'KeepCache = Cache
-  CacheType 'NoCache = ()
+type CacheType (keep :: Bool) = KeepType keep Cache
 
 -- | Enables or disables a boolean indicating whether a transaction is done
-type family LastType (keepLast :: KeepLast) where
-  LastType 'KeepLast = Bool
-  LastType 'NoLast = ()
+type LastType (keep :: Bool) = KeepType keep Bool
 
 -- | Enables or disables 'AtomicAccess'
-type family LockType (keepLockType :: KeepLock) where
-  LockType 'KeepLock = AtomicAccess
-  LockType 'NoLock = ()
+type LockType (keep :: Bool) = KeepType keep AtomicAccess
 
 -- | Enables or disables 'Privileged', 'Secure', and 'InstructionOrData'
-type family PermissionsType (keepPermissions :: KeepPermissions) where
-  PermissionsType 'KeepPermissions = T3 Privileged Secure InstructionOrData
-  PermissionsType 'NoPermissions = ()
+type PermissionsType (keep :: Bool) = KeepType keep (T3 Privileged Secure InstructionOrData)
 
 -- | Enables or disables 'Qos'
-type family QosType (keepQos :: KeepQos) where
-  QosType 'KeepQos = Qos
-  QosType 'NoQos = ()
+type QosType (keep :: Bool) = KeepType keep Qos
 
 -- | Enables or disables region type
-type family RegionType (keepRegion :: KeepRegion) where
-  RegionType 'KeepRegion = C.BitVector 4
-  RegionType 'NoRegion = ()
+type RegionType (keep :: Bool) = KeepType keep (C.BitVector 4)
 
 -- | Enables or disables 'Resp'
-type family ResponseType (keepResponse :: KeepResponse) where
-  ResponseType 'KeepResponse = Resp
-  ResponseType 'NoResponse = ()
+type ResponseType (keep :: Bool) = KeepType keep Resp
 
 -- | Enables or disables 'BurstSize'
-type family SizeType (keepSize :: KeepSize) where
-  SizeType 'KeepSize = BurstSize
-  SizeType 'NoSize = ()
+type SizeType (keep :: Bool) = KeepType keep BurstSize
 
--- | Enable or disable 'Strobe'
-type family StrobeType (byteSize :: Nat) (keepStrobe :: KeepStrobe) where
-  StrobeType byteSize 'KeepStrobe = Strobe byteSize
-  StrobeType byteSize 'NoStrobe = ()
+-- | @byteSize@ bytes of data,
+-- with @keepStrobe@ determining whether to include a strobe value or not.
+type StrictStrobeType (byteSize :: Nat) (keepStrobe :: Bool)
+  = C.Vec byteSize (StrobeDataType keepStrobe)
 
--- | Enable or disable 'Strobe'
-type family StrictStrobeType (byteSize :: Nat) (keepStrobe :: KeepStrobe) where
-  StrictStrobeType byteSize 'KeepStrobe = C.Vec byteSize (Maybe (C.BitVector 8))
-  StrictStrobeType byteSize 'NoStrobe = C.BitVector (byteSize * 8)
+-- | Enable or disable a strobe value.
+type family StrobeDataType (keepStrobe :: Bool) = t | t -> keepStrobe where
+  StrobeDataType 'True = Maybe (C.BitVector 8)
+  StrobeDataType 'False = C.BitVector 8
 
--- | Indicates valid bytes on data field.
-type Strobe (byteSize :: Nat) = C.BitVector byteSize
+-- | We want to define operations on 'StrobeDataType' that work for both possibilities
+-- (@keepStrobe = 'True@ and @keepStrobe = 'False@), but we can't pattern match directly.
+-- Instead we need to define a class and instantiate
+-- the class for both @'True@ and @'False@.
+class KeepStrobeClass (keepStrobe :: Bool) where
+  -- | Get the value of @keepStrobe@ at the term level.
+  getKeepStrobe :: StrobeDataType keepStrobe -> Bool
+  -- | Convert a byte into a possibly-strobed byte.
+  -- The 'Bool' value determines the strobe value
+  -- if strobe is enabled.
+  toStrobeDataType :: Bool -> C.BitVector 8 -> StrobeDataType keepStrobe
+  -- | Convert a possibly-strobed byte into a byte,
+  -- or 'Nothing' if strobe is enabled and strobe = false.
+  fromStrobeDataType :: StrobeDataType keepStrobe -> Maybe (C.BitVector 8)
+
+instance KeepStrobeClass 'True where
+  getKeepStrobe _ = True
+  toStrobeDataType True d = Just d
+  toStrobeDataType False _ = Nothing
+  fromStrobeDataType v = v
+
+instance KeepStrobeClass 'False where
+  getKeepStrobe _ = False
+  toStrobeDataType _ d = d
+  fromStrobeDataType v = Just v
 
 -- | The protocol does not specify the exact use of the QoS identifier. This
 -- specification recommends that AxQOS is used as a priority indicator for the

--- a/src/Protocols/Axi4/ReadAddress.hs
+++ b/src/Protocols/Axi4/ReadAddress.hs
@@ -15,6 +15,20 @@ module Protocols.Axi4.ReadAddress
   , S2M_ReadAddress(..)
   , Axi4ReadAddress
   , mapFull
+
+    -- * configuration
+  , Axi4ReadAddressConfig(..)
+  , GoodAxi4ReadAddressConfig
+  , ARKeepBurst
+  , ARKeepSize
+  , ARIdWidth
+  , ARAddrWidth
+  , ARKeepRegion
+  , ARKeepBurstLength
+  , ARKeepLock
+  , ARKeepCache
+  , ARKeepPermissions
+  , ARKeepQos
   ) where
 
 -- base
@@ -32,38 +46,102 @@ import Protocols.Internal
 import Protocols.DfLike (DfLike)
 import qualified Protocols.DfLike as DfLike
 
+-- | Configuration options for 'Axi4ReadAddress'.
+data Axi4ReadAddressConfig = Axi4ReadAddressConfig
+  { _arKeepBurst       :: Bool
+  , _arKeepSize        :: Bool
+  , _arIdWidth         :: C.Nat
+  , _arAddrWidth       :: C.Nat
+  , _arKeepRegion      :: Bool
+  , _arKeepBurstLength :: Bool
+  , _arKeepLock        :: Bool
+  , _arKeepCache       :: Bool
+  , _arKeepPermissions :: Bool
+  , _arKeepQos         :: Bool
+  }
+
+-- | Grab '_arKeepBurst' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arburst' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepBurst (conf :: Axi4ReadAddressConfig) where
+  ARKeepBurst ('Axi4ReadAddressConfig a _ _ _ _ _ _ _ _ _) = a
+
+-- | Grab '_arKeepSize' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arsize' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepSize (conf :: Axi4ReadAddressConfig) where
+  ARKeepSize ('Axi4ReadAddressConfig _ a _ _ _ _ _ _ _ _) = a
+
+-- | Grab '_arIdWidth' from 'Axi4ReadAddressConfig' at the type level.
+-- This nat value determines the size of the '_arid' field
+-- in 'M2S_ReadAddress'.
+type family ARIdWidth (conf :: Axi4ReadAddressConfig) where
+  ARIdWidth ('Axi4ReadAddressConfig _ _ a _ _ _ _ _ _ _) = a
+
+-- | Grab '_arAddrWidth' from 'Axi4ReadAddressConfig' at the type level.
+-- This nat value determines the size of the '_araddr' field
+-- in 'M2S_ReadAddress'.
+type family ARAddrWidth (conf :: Axi4ReadAddressConfig) where
+  ARAddrWidth ('Axi4ReadAddressConfig _ _ _ a _ _ _ _ _ _) = a
+
+-- | Grab '_arKeepRegion' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arregion' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepRegion (conf :: Axi4ReadAddressConfig) where
+  ARKeepRegion ('Axi4ReadAddressConfig _ _ _ _ a _ _ _ _ _) = a
+
+-- | Grab '_arKeepBurstLength' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arlen' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepBurstLength (conf :: Axi4ReadAddressConfig) where
+  ARKeepBurstLength ('Axi4ReadAddressConfig _ _ _ _ _ a _ _ _ _) = a
+
+-- | Grab '_arKeepLock' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arlock' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepLock (conf :: Axi4ReadAddressConfig) where
+  ARKeepLock ('Axi4ReadAddressConfig _ _ _ _ _ _ a _ _ _) = a
+
+-- | Grab '_arKeepCache' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arcache' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepCache (conf :: Axi4ReadAddressConfig) where
+  ARKeepCache ('Axi4ReadAddressConfig _ _ _ _ _ _ _ a _ _) = a
+
+-- | Grab '_arKeepPermissions' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arprot' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepPermissions (conf :: Axi4ReadAddressConfig) where
+  ARKeepPermissions ('Axi4ReadAddressConfig _ _ _ _ _ _ _ _ a _) = a
+
+-- | Grab '_arKeepQos' from 'Axi4ReadAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_arqos' field
+-- in 'M2S_ReadAddress'.
+type family ARKeepQos (conf :: Axi4ReadAddressConfig) where
+  ARKeepQos ('Axi4ReadAddressConfig _ _ _ _ _ _ _ _ _ a) = a
+
 -- | AXI4 Read Address channel protocol
 data Axi4ReadAddress
   (dom :: C.Domain)
-  (kb :: KeepBurst)
-  (ksz :: KeepSize)
-  (lw :: LengthWidth)
-  (iw :: IdWidth)
-  (aw :: AddrWidth)
-  (kr :: KeepRegion)
-  (kbl :: KeepBurstLength)
-  (kl :: KeepLock)
-  (kc :: KeepCache)
-  (kp :: KeepPermissions)
-  (kq :: KeepQos)
+  (conf :: Axi4ReadAddressConfig)
   (userType :: Type)
 
-instance Protocol (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
-  type Fwd (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
-    C.Signal dom (M2S_ReadAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
-  type Bwd (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
+instance Protocol (Axi4ReadAddress dom conf userType) where
+  type Fwd (Axi4ReadAddress dom conf userType) =
+    C.Signal dom (M2S_ReadAddress conf userType)
+  type Bwd (Axi4ReadAddress dom conf userType) =
     C.Signal dom S2M_ReadAddress
 
-instance Backpressure (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
+instance Backpressure (Axi4ReadAddress dom conf userType) where
   boolsToBwd _ = C.fromList_lazy . coerce
 
-instance DfLike dom (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType where
-  type Data (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType =
-    M2S_ReadAddress kb ksz lw iw aw kr kbl kl kc kp kq userType
+instance DfLike dom (Axi4ReadAddress dom conf) userType where
+  type Data (Axi4ReadAddress dom conf) userType =
+    M2S_ReadAddress conf userType
 
   type Payload userType = userType
 
-  type Ack (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType =
+  type Ack (Axi4ReadAddress dom conf) userType =
     S2M_ReadAddress
 
   getPayload _ (M2S_ReadAddress{_aruser}) = Just _aruser
@@ -84,15 +162,15 @@ instance DfLike dom (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) use
   {-# INLINE ackToBool #-}
 
 instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType) =>
-  Simulate (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
+  Simulate (Axi4ReadAddress dom conf userType) where
 
-  type SimulateFwdType (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
-    [M2S_ReadAddress kb ksz lw iw aw kr kbl kl kc kp kq userType]
+  type SimulateFwdType (Axi4ReadAddress dom conf userType) =
+    [M2S_ReadAddress conf userType]
 
-  type SimulateBwdType (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
+  type SimulateBwdType (Axi4ReadAddress dom conf userType) =
     [S2M_ReadAddress]
 
-  type SimulateChannels (Axi4ReadAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) = 1
+  type SimulateChannels (Axi4ReadAddress dom conf userType) = 1
 
   simToSigFwd Proxy = C.fromList_lazy
   simToSigBwd Proxy = C.fromList_lazy
@@ -105,49 +183,39 @@ instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType
 -- | See Table A2-5 "Read address channel signals"
 
 data M2S_ReadAddress
-  (kb :: KeepBurst)
-  (ksz :: KeepSize)
-  (lw :: LengthWidth)
-  (iw :: IdWidth)
-  (aw :: AddrWidth)
-  (kr :: KeepRegion)
-  (kbl :: KeepBurstLength)
-  (kl :: KeepLock)
-  (kc :: KeepCache)
-  (kp :: KeepPermissions)
-  (kq :: KeepQos)
+  (conf :: Axi4ReadAddressConfig)
   (userType :: Type)
   = M2S_NoReadAddress
   | M2S_ReadAddress
     { -- | Read address id*
-      _arid :: !(C.BitVector (Width iw))
+      _arid :: !(C.BitVector (ARIdWidth conf))
 
       -- | Read address
-    , _araddr :: !(C.BitVector (Width aw))
+    , _araddr :: !(C.BitVector (ARAddrWidth conf))
 
       -- | Read region*
-    , _arregion :: !(RegionType kr)
+    , _arregion :: !(RegionType (ARKeepRegion conf))
 
       -- | Burst length*
-    , _arlen :: !(BurstLengthType kbl)
+    , _arlen :: !(BurstLengthType (ARKeepBurstLength conf))
 
       -- | Burst size*
-    , _arsize :: !(SizeType ksz)
+    , _arsize :: !(SizeType (ARKeepSize conf))
 
       -- | Burst type*
-    , _arburst :: !(BurstType kb)
+    , _arburst :: !(BurstType (ARKeepBurst conf))
 
       -- | Lock type*
-    , _arlock :: !(LockType kl)
+    , _arlock :: !(LockType (ARKeepLock conf))
 
       -- | Cache type* (has been renamed to modifiable in AXI spec)
-    , _arcache :: !(CacheType kc)
+    , _arcache :: !(CacheType (ARKeepCache conf))
 
       -- | Protection type
-    , _arprot :: !(PermissionsType kp)
+    , _arprot :: !(PermissionsType (ARKeepPermissions conf))
 
       -- | QoS value
-    , _arqos :: !(QosType kq)
+    , _arqos :: !(QosType (ARKeepQos conf))
 
       -- | User data
     , _aruser :: !userType
@@ -159,48 +227,96 @@ newtype S2M_ReadAddress = S2M_ReadAddress
   { _arready :: Bool }
   deriving (Show, Generic, C.NFDataX)
 
-deriving instance
-  ( C.KnownNat (Width iw)
-  , C.KnownNat (Width aw)
-  , Show (SizeType ksz)
-  , Show (BurstType kb)
-  , Show userType
-  , Show (RegionType kr)
-  , Show (BurstLengthType kbl)
-  , Show (LockType kl)
-  , Show (CacheType kc)
-  , Show (PermissionsType kp)
-  , Show (QosType kq) ) =>
-  Show (M2S_ReadAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
+-- | Shorthand for a "well-behaved" read address config,
+-- so that we don't need to write out a bunch of type constraints later.
+-- Holds for every configuration; don't worry about implementing this class.
+class
+  ( KeepTypeClass (ARKeepBurst conf)
+  , KeepTypeClass (ARKeepSize conf)
+  , KeepTypeClass (ARKeepRegion conf)
+  , KeepTypeClass (ARKeepBurstLength conf)
+  , KeepTypeClass (ARKeepLock conf)
+  , KeepTypeClass (ARKeepCache conf)
+  , KeepTypeClass (ARKeepPermissions conf)
+  , KeepTypeClass (ARKeepQos conf)
+
+  , C.KnownNat (ARIdWidth conf)
+  , C.KnownNat (ARAddrWidth conf)
+
+  , Show (RegionType (ARKeepRegion conf))
+  , Show (BurstLengthType (ARKeepBurstLength conf))
+  , Show (SizeType (ARKeepSize conf))
+  , Show (BurstType (ARKeepBurst conf))
+  , Show (LockType (ARKeepLock conf))
+  , Show (CacheType (ARKeepCache conf))
+  , Show (PermissionsType (ARKeepPermissions conf))
+  , Show (QosType (ARKeepQos conf))
+
+  , C.NFDataX (RegionType (ARKeepRegion conf))
+  , C.NFDataX (BurstLengthType (ARKeepBurstLength conf))
+  , C.NFDataX (SizeType (ARKeepSize conf))
+  , C.NFDataX (BurstType (ARKeepBurst conf))
+  , C.NFDataX (LockType (ARKeepLock conf))
+  , C.NFDataX (CacheType (ARKeepCache conf))
+  , C.NFDataX (PermissionsType (ARKeepPermissions conf))
+  , C.NFDataX (QosType (ARKeepQos conf))
+  ) => GoodAxi4ReadAddressConfig conf
+
+instance
+  ( KeepTypeClass (ARKeepBurst conf)
+  , KeepTypeClass (ARKeepSize conf)
+  , KeepTypeClass (ARKeepRegion conf)
+  , KeepTypeClass (ARKeepBurstLength conf)
+  , KeepTypeClass (ARKeepLock conf)
+  , KeepTypeClass (ARKeepCache conf)
+  , KeepTypeClass (ARKeepPermissions conf)
+  , KeepTypeClass (ARKeepQos conf)
+
+  , C.KnownNat (ARIdWidth conf)
+  , C.KnownNat (ARAddrWidth conf)
+
+  , Show (RegionType (ARKeepRegion conf))
+  , Show (BurstLengthType (ARKeepBurstLength conf))
+  , Show (SizeType (ARKeepSize conf))
+  , Show (BurstType (ARKeepBurst conf))
+  , Show (LockType (ARKeepLock conf))
+  , Show (CacheType (ARKeepCache conf))
+  , Show (PermissionsType (ARKeepPermissions conf))
+  , Show (QosType (ARKeepQos conf))
+
+  , C.NFDataX (RegionType (ARKeepRegion conf))
+  , C.NFDataX (BurstLengthType (ARKeepBurstLength conf))
+  , C.NFDataX (SizeType (ARKeepSize conf))
+  , C.NFDataX (BurstType (ARKeepBurst conf))
+  , C.NFDataX (LockType (ARKeepLock conf))
+  , C.NFDataX (CacheType (ARKeepCache conf))
+  , C.NFDataX (PermissionsType (ARKeepPermissions conf))
+  , C.NFDataX (QosType (ARKeepQos conf))
+  ) => GoodAxi4ReadAddressConfig conf
 
 deriving instance
-  ( C.NFDataX userType
-  , C.NFDataX (BurstType kb)
-  , C.NFDataX (SizeType ksz)
-  , C.NFDataX (BurstType kb)
-  , C.NFDataX userType
-  , C.NFDataX (RegionType kr)
-  , C.NFDataX (BurstLengthType kbl)
-  , C.NFDataX (LockType kl)
-  , C.NFDataX (CacheType kc)
-  , C.NFDataX (PermissionsType kp)
-  , C.NFDataX (QosType kq)
-  , C.KnownNat (Width iw)
-  , C.KnownNat (Width aw)
+  ( GoodAxi4ReadAddressConfig conf
+  , Show userType
   ) =>
-  C.NFDataX (M2S_ReadAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
+  Show (M2S_ReadAddress conf userType)
+
+deriving instance
+  ( GoodAxi4ReadAddressConfig conf
+  , C.NFDataX userType
+  ) =>
+  C.NFDataX (M2S_ReadAddress conf userType)
 
 -- | Circuit that transforms the LHS 'Axi4ReadAddress' protocol to a
 -- version using different type parameters according to two functions
 -- that can transform the data and ack signal to and from the other protocol.
 mapFull ::
   forall dom
-    kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 t1
-    kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 t2 .
-  (M2S_ReadAddress kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 t1 ->
-    M2S_ReadAddress kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 t2) ->
+    conf1 t1
+    conf2 t2 .
+  (M2S_ReadAddress conf1 t1 ->
+    M2S_ReadAddress conf2 t2) ->
   (S2M_ReadAddress -> S2M_ReadAddress) ->
   Circuit
-    (Axi4ReadAddress dom kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 t1)
-    (Axi4ReadAddress dom kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 t2)
+    (Axi4ReadAddress dom conf1 t1)
+    (Axi4ReadAddress dom conf2 t2)
 mapFull = DfLike.mapDfLike Proxy Proxy

--- a/src/Protocols/Axi4/ReadData.hs
+++ b/src/Protocols/Axi4/ReadData.hs
@@ -16,6 +16,12 @@ module Protocols.Axi4.ReadData
   , Axi4ReadData
   , mapFull
 
+    -- * configuration
+  , Axi4ReadDataConfig(..)
+  , GoodAxi4ReadDataConfig
+  , RKeepResponse
+  , RIdWidth
+
     -- * Operations on Df like protocols
   , const, void, pure
   , map, bimap
@@ -61,30 +67,47 @@ import Protocols.Internal
 import Protocols.DfLike (DfLike)
 import qualified Protocols.DfLike as DfLike
 
+-- | Configuration options for 'Axi4ReadData'.
+data Axi4ReadDataConfig = Axi4ReadDataConfig
+  { _rKeepResponse :: Bool
+  , _rIdWidth      :: C.Nat
+  }
+
+-- | Grab '_rKeepResponse' from 'Axi4ReadDataConfig' at the type level.
+-- This boolean value determines whether to keep the '_rresp' field
+-- in 'S2M_ReadData'.
+type family RKeepResponse (conf :: Axi4ReadDataConfig) where
+  RKeepResponse ('Axi4ReadDataConfig a _) = a
+
+-- | Grab '_rIdWidth' from 'Axi4ReadDataConfig' at the type level.
+-- This nat value determines the size of the '_rid' field
+-- in 'S2M_ReadData'.
+type family RIdWidth (conf :: Axi4ReadDataConfig) where
+  RIdWidth ('Axi4ReadDataConfig _ a) = a
+
 -- | AXI4 Read Data channel protocol
 data Axi4ReadData
   (dom :: C.Domain)
-  (kr :: KeepResponse)
-  (iw :: IdWidth)
+  (conf :: Axi4ReadDataConfig)
   (userType :: Type)
   (dataType :: Type)
 
-instance Protocol (Axi4ReadData dom kr iw userType dataType) where
-  type Fwd (Axi4ReadData dom kr iw userType dataType) =
-    C.Signal dom (S2M_ReadData kr iw userType dataType)
-  type Bwd (Axi4ReadData dom kr iw userType dataType) =
+instance Protocol (Axi4ReadData dom conf userType dataType) where
+  type Fwd (Axi4ReadData dom conf userType dataType) =
+    C.Signal dom (S2M_ReadData conf userType dataType)
+  type Bwd (Axi4ReadData dom conf userType dataType) =
     C.Signal dom M2S_ReadData
 
-instance Backpressure (Axi4ReadData dom kr iw userType dataType) where
+instance Backpressure (Axi4ReadData dom conf userType dataType) where
   boolsToBwd _ = C.fromList_lazy . coerce
 
-instance DfLike dom (Axi4ReadData dom kr iw userType) dataType where
-  type Data (Axi4ReadData dom kr iw userType) dataType =
-    S2M_ReadData kr iw userType dataType
+instance DfLike dom (Axi4ReadData dom conf userType) dataType where
+  type Data (Axi4ReadData dom conf userType) dataType =
+    S2M_ReadData conf userType dataType
 
   type Payload dataType = dataType
 
-  type Ack (Axi4ReadData dom kr iw userType) dataType  =
+  type Ack (Axi4ReadData dom conf userType) dataType  =
     M2S_ReadData
 
   getPayload _ (S2M_ReadData{_rdata}) = Just _rdata
@@ -105,15 +128,15 @@ instance DfLike dom (Axi4ReadData dom kr iw userType) dataType where
   {-# INLINE ackToBool #-}
 
 instance (C.KnownDomain dom, C.NFDataX dataType, C.ShowX dataType, Show dataType) =>
-  Simulate (Axi4ReadData dom kr iw userType dataType) where
+  Simulate (Axi4ReadData dom conf userType dataType) where
 
-  type SimulateFwdType (Axi4ReadData dom kr iw userType dataType) =
-    [S2M_ReadData kr iw userType dataType]
+  type SimulateFwdType (Axi4ReadData dom conf userType dataType) =
+    [S2M_ReadData conf userType dataType]
 
-  type SimulateBwdType (Axi4ReadData dom kr iw userType dataType) =
+  type SimulateBwdType (Axi4ReadData dom conf userType dataType) =
     [M2S_ReadData]
 
-  type SimulateChannels (Axi4ReadData dom kr iw userType dataType) = 1
+  type SimulateChannels (Axi4ReadData dom conf userType dataType) = 1
 
   simToSigFwd Proxy = C.fromList_lazy
   simToSigBwd Proxy = C.fromList_lazy
@@ -125,20 +148,19 @@ instance (C.KnownDomain dom, C.NFDataX dataType, C.ShowX dataType, Show dataType
 
 -- | See Table A2-6 "Read data channel signals"
 data S2M_ReadData
-  (kr :: KeepResponse)
-  (iw :: IdWidth)
+  (conf :: Axi4ReadDataConfig)
   (userType :: Type)
   (dataType :: Type)
   = S2M_NoReadData
   | S2M_ReadData
     { -- | Read address id*
-      _rid :: !(C.BitVector (Width iw))
+      _rid :: !(C.BitVector (RIdWidth conf))
 
     , -- | Read data
       _rdata :: !dataType
 
       -- | Read response
-    , _rresp :: !(ResponseType kr)
+    , _rresp :: !(ResponseType (RKeepResponse conf))
 
       -- | Read last
     , _rlast :: !Bool
@@ -152,258 +174,273 @@ data S2M_ReadData
 newtype M2S_ReadData = M2S_ReadData { _rready :: Bool }
   deriving (Show, Generic, C.NFDataX)
 
-deriving instance
-  ( C.NFDataX userType
-  , C.NFDataX dataType
-  , C.NFDataX (ResponseType kr)
-  , C.KnownNat (Width iw)
-  ) =>
-  C.NFDataX (S2M_ReadData kr iw userType dataType)
+-- | Shorthand for a "well-behaved" read data config,
+-- so that we don't need to write out a bunch of type constraints later.
+-- Holds for every configuration; don't worry about implementing this class.
+class
+  ( KeepTypeClass (RKeepResponse conf)
+  , C.KnownNat (RIdWidth conf)
+  , Show (ResponseType (RKeepResponse conf))
+  , C.NFDataX (ResponseType (RKeepResponse conf))
+  ) => GoodAxi4ReadDataConfig conf
+
+instance
+  ( KeepTypeClass (RKeepResponse conf)
+  , C.KnownNat (RIdWidth conf)
+  , Show (ResponseType (RKeepResponse conf))
+  , C.NFDataX (ResponseType (RKeepResponse conf))
+  ) => GoodAxi4ReadDataConfig conf
 
 deriving instance
-  ( C.KnownNat (Width iw)
+  ( GoodAxi4ReadDataConfig conf
   , Show userType
   , Show dataType
-  , Show (ResponseType kr) ) =>
-  Show (S2M_ReadData kr iw userType dataType)
+  ) =>
+  Show (S2M_ReadData conf userType dataType)
+
+deriving instance
+  ( GoodAxi4ReadDataConfig conf
+  , C.NFDataX userType
+  , C.NFDataX dataType
+  ) =>
+  C.NFDataX (S2M_ReadData conf userType dataType)
 
 
 -- | Like 'P.map', but over the data in the AXI4 read channel.
 map :: (a -> b) -> Circuit
-  (Axi4ReadData dom kr iw userType a)
-  (Axi4ReadData dom kr iw userType b)
+  (Axi4ReadData dom conf userType a)
+  (Axi4ReadData dom conf userType b)
 map = DfLike.map Proxy Proxy
 
 -- | Like 'bimap', but over the data in the AXI4 read channel.
 bimap :: Bifunctor p => (a -> b) -> (c -> d) -> Circuit
-  (Axi4ReadData dom kr iw userType (p a c))
-  (Axi4ReadData dom kr iw userType (p b d))
+  (Axi4ReadData dom conf userType (p a c))
+  (Axi4ReadData dom conf userType (p b d))
 bimap = DfLike.bimap
 
 -- | Like 'P.fst', but over the data in the AXI4 read channel.
 fst :: Circuit
-  (Axi4ReadData dom kr iw userType (a, b))
-  (Axi4ReadData dom kr iw userType a)
+  (Axi4ReadData dom conf userType (a, b))
+  (Axi4ReadData dom conf userType a)
 fst = DfLike.fst
 
 -- | Like 'P.snd', but over the data in the AXI4 read channel.
 snd :: Circuit
-  (Axi4ReadData dom kr iw userType (a, b))
-  (Axi4ReadData dom kr iw userType b)
+  (Axi4ReadData dom conf userType (a, b))
+  (Axi4ReadData dom conf userType b)
 snd = DfLike.snd
 
 -- | Like 'Data.Bifunctor.first', but over the data in the AXI4 read channel.
 first :: Bifunctor p => (a -> b) -> Circuit
-  (Axi4ReadData dom kr iw userType (p a c))
-  (Axi4ReadData dom kr iw userType (p b c))
+  (Axi4ReadData dom conf userType (p a c))
+  (Axi4ReadData dom conf userType (p b c))
 first = DfLike.first
 
 -- | Like 'Data.Bifunctor.second', but over the data in the AXI4 read channel.
 second :: Bifunctor p => (b -> c) -> Circuit
-  (Axi4ReadData dom kr iw userType (p a b))
-  (Axi4ReadData dom kr iw userType (p a c))
+  (Axi4ReadData dom conf userType (p a b))
+  (Axi4ReadData dom conf userType (p a c))
 second = DfLike.second
 
 -- | Acknowledge but ignore data from LHS protocol. Send a static value /b/.
-const :: C.HiddenReset dom => S2M_ReadData kr iw userType b -> Circuit
-  (Axi4ReadData dom kr iw userType a)
-  (Axi4ReadData dom kr iw userType b)
+const :: C.HiddenReset dom => S2M_ReadData conf userType b -> Circuit
+  (Axi4ReadData dom conf userType a)
+  (Axi4ReadData dom conf userType b)
 const = DfLike.const Proxy Proxy
 
 -- | Drive a constant value composed of /a/.
-pure :: S2M_ReadData kr iw userType a -> Circuit
+pure :: S2M_ReadData conf userType a -> Circuit
   ()
-  (Axi4ReadData dom kr iw userType a)
+  (Axi4ReadData dom conf userType a)
 pure = DfLike.pure Proxy
 
 -- | Drive a constant value composed of /a/.
-void :: C.HiddenReset dom => Circuit (Axi4ReadData dom kr iw userType a) ()
+void :: C.HiddenReset dom => Circuit (Axi4ReadData dom conf userType a) ()
 void = DfLike.void Proxy
 
 -- | Like 'Data.Maybe.catMaybes', but over a AXI4 read data stream.
 catMaybes :: Circuit
-  (Axi4ReadData dom kr iw userType (Maybe a))
-  (Axi4ReadData dom kr iw userType a)
+  (Axi4ReadData dom conf userType (Maybe a))
+  (Axi4ReadData dom conf userType a)
 catMaybes = DfLike.catMaybes Proxy Proxy
 
 -- | Like 'Data.Maybe.mapMaybe', but over payload (/a/) of a AXI4 read data stream.
 mapMaybe :: (a -> Maybe b) -> Circuit
-  (Axi4ReadData dom kr iw userType a)
-  (Axi4ReadData dom kr iw userType b)
+  (Axi4ReadData dom conf userType a)
+  (Axi4ReadData dom conf userType b)
 mapMaybe = DfLike.mapMaybe
 
 -- | Like 'P.filter', but over a AXI4 read data stream.
-filter :: forall dom a kr iw userType. (a -> Bool) -> Circuit
-  (Axi4ReadData dom kr iw userType a)
-  (Axi4ReadData dom kr iw userType a)
+filter :: forall dom a conf userType. (a -> Bool) -> Circuit
+  (Axi4ReadData dom conf userType a)
+  (Axi4ReadData dom conf userType a)
 filter = DfLike.filter Proxy
 
 -- | Like 'Data.Either.Combinators.mapLeft', but over the data in the AXI4 read channel.
 mapLeft :: (a -> b) -> Circuit
-  (Axi4ReadData dom kr iw userType (Either a c))
-  (Axi4ReadData dom kr iw userType (Either b c))
+  (Axi4ReadData dom conf userType (Either a c))
+  (Axi4ReadData dom conf userType (Either b c))
 mapLeft = DfLike.mapLeft
 
 -- | Like 'Data.Either.Combinators.mapRight', but over the data in the AXI4 read channel.
 mapRight :: (b -> c) -> Circuit
-  (Axi4ReadData dom kr iw userType (Either a b))
-  (Axi4ReadData dom kr iw userType (Either a c))
+  (Axi4ReadData dom conf userType (Either a b))
+  (Axi4ReadData dom conf userType (Either a c))
 mapRight = DfLike.mapRight
 
 -- | Like 'Data.Either.either', but over a AXI4 read data stream.
 either :: (a -> c) -> (b -> c) -> Circuit
-  (Axi4ReadData dom kr iw userType (Either a b))
-  (Axi4ReadData dom kr iw userType c)
+  (Axi4ReadData dom conf userType (Either a b))
+  (Axi4ReadData dom conf userType c)
 either = DfLike.either
 
 
 -- | Like 'P.zipWith', but over two AXI4 read data streams.
 zipWith ::
-  forall dom a b c kr iw userType .
+  forall dom a b c conf userType .
   (a -> b -> c) ->
   Circuit
-    (Axi4ReadData dom kr iw userType a, Axi4ReadData dom kr iw userType b)
-    (Axi4ReadData dom kr iw userType c)
+    (Axi4ReadData dom conf userType a, Axi4ReadData dom conf userType b)
+    (Axi4ReadData dom conf userType c)
 zipWith = DfLike.zipWith Proxy Proxy Proxy
 
 -- | Like 'P.zip', but over two AXI4 read data streams.
-zip :: forall a b dom kr iw userType . Circuit
-  (Axi4ReadData dom kr iw userType a, Axi4ReadData dom kr iw userType b)
-  (Axi4ReadData dom kr iw userType (a, b))
+zip :: forall a b dom conf userType . Circuit
+  (Axi4ReadData dom conf userType a, Axi4ReadData dom conf userType b)
+  (Axi4ReadData dom conf userType (a, b))
 zip = DfLike.zip Proxy Proxy Proxy
 
 -- | Like 'P.partition', but over AXI4 read data streams
-partition :: forall dom a kr iw userType. (a -> Bool) -> Circuit
-  (Axi4ReadData dom kr iw userType a)
-  (Axi4ReadData dom kr iw userType a, Axi4ReadData dom kr iw userType a)
+partition :: forall dom a conf userType. (a -> Bool) -> Circuit
+  (Axi4ReadData dom conf userType a)
+  (Axi4ReadData dom conf userType a, Axi4ReadData dom conf userType a)
 partition = DfLike.partition Proxy
 
 
 -- | Route a AXI4 read data stream to another corresponding to the index
 route ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   C.KnownNat n => Circuit
-    (Axi4ReadData dom kr iw userType (C.Index n, a))
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
+    (Axi4ReadData dom conf userType (C.Index n, a))
+    (C.Vec n (Axi4ReadData dom conf userType a))
 route = DfLike.route Proxy Proxy
 
 
 -- | Select data from the channel indicated by the AXI4 read data stream carrying
 -- @Index n@.
 select ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   C.KnownNat n =>
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a), Axi4ReadData dom kr iw userType (C.Index n))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a), Axi4ReadData dom conf userType (C.Index n))
+    (Axi4ReadData dom conf userType a)
 select = DfLike.select
 
 
 
 -- | Select /selectN/ samples from channel /n/.
 selectN ::
-  forall n selectN dom a kr iw userType.
+  forall n selectN dom a conf userType.
   ( C.HiddenClockResetEnable dom
   , C.KnownNat selectN
   , C.KnownNat n
   ) =>
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a), Axi4ReadData dom kr iw userType (C.Index n, C.Index selectN))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a), Axi4ReadData dom conf userType (C.Index n, C.Index selectN))
+    (Axi4ReadData dom conf userType a)
 selectN = DfLike.selectN Proxy Proxy
 
 -- | Selects samples from channel /n/ until the predicate holds. The cycle in
 -- which the predicate turns true is included.
 selectUntil ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   C.KnownNat n =>
   (a -> Bool) ->
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a), Axi4ReadData dom kr iw userType (C.Index n))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a), Axi4ReadData dom conf userType (C.Index n))
+    (Axi4ReadData dom conf userType a)
 selectUntil = DfLike.selectUntil Proxy Proxy
 
 -- | Copy data of a single AXI4 read data stream to multiple. LHS will only receive
 -- an acknowledgement when all RHS receivers have acknowledged data.
 fanout ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, C.HiddenClockResetEnable dom, 1 C.<= n) =>
   Circuit
-    (Axi4ReadData dom kr iw userType a)
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
+    (Axi4ReadData dom conf userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a))
 fanout = DfLike.fanout Proxy
 
 -- | Merge data of multiple AXI4 read data streams using a user supplied function
 fanin ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, 1 C.<= n) =>
   (a -> a -> a) ->
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a))
+    (Axi4ReadData dom conf userType a)
 fanin = DfLike.fanin
 
 -- | Merge data of multiple AXI4 read data streams using Monoid's '<>'.
 mfanin ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, Monoid a, 1 C.<= n) =>
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a))
+    (Axi4ReadData dom conf userType a)
 mfanin = DfLike.mfanin
 
 -- | Bundle a vector of AXI4 read data streams into one.
 bundleVec ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, 1 C.<= n) =>
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
-    (Axi4ReadData dom kr iw userType (C.Vec n a))
+    (C.Vec n (Axi4ReadData dom conf userType a))
+    (Axi4ReadData dom conf userType (C.Vec n a))
 bundleVec = DfLike.bundleVec Proxy Proxy
 
 -- | Split up a AXI4 read data stream of a vector into multiple independent AXI4 read data streams.
 unbundleVec ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, C.NFDataX a, C.HiddenClockResetEnable dom, 1 C.<= n) =>
   Circuit
-    (Axi4ReadData dom kr iw userType (C.Vec n a))
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
+    (Axi4ReadData dom conf userType (C.Vec n a))
+    (C.Vec n (Axi4ReadData dom conf userType a))
 unbundleVec = DfLike.unbundleVec Proxy Proxy
 
 -- | Distribute data across multiple components on the RHS. Useful if you want
 -- to parallelize a workload across multiple (slow) workers. For optimal
 -- throughput, you should make sure workers can accept data every /n/ cycles.
 roundrobin ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, C.HiddenClockResetEnable dom, 1 C.<= n) =>
   Circuit
-    (Axi4ReadData dom kr iw userType a)
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
+    (Axi4ReadData dom conf userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a))
 roundrobin = DfLike.roundrobin Proxy
 
 -- | Opposite of 'roundrobin'. Useful to collect data from workers that only
 -- produce a result with an interval of /n/ cycles.
 roundrobinCollect ::
-  forall n dom a kr iw userType .
+  forall n dom a conf userType .
   (C.KnownNat n, C.HiddenClockResetEnable dom, 1 C.<= n) =>
   DfLike.CollectMode ->
   Circuit
-    (C.Vec n (Axi4ReadData dom kr iw userType a))
-    (Axi4ReadData dom kr iw userType a)
+    (C.Vec n (Axi4ReadData dom conf userType a))
+    (Axi4ReadData dom conf userType a)
 roundrobinCollect = DfLike.roundrobinCollect Proxy
 
 -- | Place register on /forward/ part of a circuit.
 registerFwd ::
-  forall dom a kr iw userType .
+  forall dom a conf userType .
   ( C.NFDataX a
   , C.HiddenClockResetEnable dom
-  , C.NFDataX (ResponseType kr)
+  , GoodAxi4ReadDataConfig conf
   , C.NFDataX userType
-  , C.KnownNat (Width iw)
   ) =>
   Circuit
-    (Axi4ReadData dom kr iw userType a)
-    (Axi4ReadData dom kr iw userType a)
+    (Axi4ReadData dom conf userType a)
+    (Axi4ReadData dom conf userType a)
 registerFwd = DfLike.registerFwd Proxy
 
 -- | Place register on /backward/ part of a circuit. This is implemented using a
@@ -411,13 +448,13 @@ registerFwd = DfLike.registerFwd Proxy
 registerBwd ::
   ( C.NFDataX a
   , C.HiddenClockResetEnable dom
-  , C.NFDataX (ResponseType kr)
+  , GoodAxi4ReadDataConfig conf
   , C.NFDataX userType
-  , C.KnownNat (Width iw)
+  , GoodAxi4ReadDataConfig conf
   ) =>
   Circuit
-    (Axi4ReadData dom kr iw userType a)
-    (Axi4ReadData dom kr iw userType a)
+    (Axi4ReadData dom conf userType a)
+    (Axi4ReadData dom conf userType a)
 registerBwd = DfLike.registerBwd Proxy
 
 
@@ -426,12 +463,11 @@ registerBwd = DfLike.registerBwd Proxy
 -- that can transform the data and ack signal accordingly to and from the other protocol.
 mapFull ::
   forall dom
-    kr1 iw1 userType1 dataType1
-    kr2 iw2 userType2 dataType2 .
-  (S2M_ReadData kr1 iw1 userType1 dataType1 -> S2M_ReadData kr2 iw2 userType2 dataType2) ->
+    conf1 userType1 dataType1
+    conf2 userType2 dataType2 .
+  (S2M_ReadData conf1 userType1 dataType1 -> S2M_ReadData conf2 userType2 dataType2) ->
   (M2S_ReadData -> M2S_ReadData) ->
   Circuit
-    (Axi4ReadData dom kr1 iw1 userType1 dataType1)
-    (Axi4ReadData dom kr2 iw2 userType2 dataType2)
+    (Axi4ReadData dom conf1 userType1 dataType1)
+    (Axi4ReadData dom conf2 userType2 dataType2)
 mapFull = DfLike.mapDfLike Proxy Proxy
-

--- a/src/Protocols/Axi4/WriteAddress.hs
+++ b/src/Protocols/Axi4/WriteAddress.hs
@@ -15,6 +15,20 @@ module Protocols.Axi4.WriteAddress
   , S2M_WriteAddress(..)
   , Axi4WriteAddress
   , mapFull
+
+    -- * configuration
+  , Axi4WriteAddressConfig(..)
+  , GoodAxi4WriteAddressConfig
+  , AWKeepBurst
+  , AWKeepSize
+  , AWIdWidth
+  , AWAddrWidth
+  , AWKeepRegion
+  , AWKeepBurstLength
+  , AWKeepLock
+  , AWKeepCache
+  , AWKeepPermissions
+  , AWKeepQos
   ) where
 
 -- base
@@ -32,38 +46,102 @@ import Protocols.Internal
 import Protocols.DfLike (DfLike)
 import qualified Protocols.DfLike as DfLike
 
+-- | Configuration options for 'Axi4WriteAddress'.
+data Axi4WriteAddressConfig = Axi4WriteAddressConfig
+  { _awKeepBurst       :: Bool
+  , _awKeepSize        :: Bool
+  , _awIdWidth         :: C.Nat
+  , _awAddrWidth       :: C.Nat
+  , _awKeepRegion      :: Bool
+  , _awKeepBurstLength :: Bool
+  , _awKeepLock        :: Bool
+  , _awKeepCache       :: Bool
+  , _awKeepPermissions :: Bool
+  , _awKeepQos         :: Bool
+  }
+
+-- | Grab '_awKeepBurst' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awburst' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepBurst (c :: Axi4WriteAddressConfig) where
+  AWKeepBurst ('Axi4WriteAddressConfig a _ _ _ _ _ _ _ _ _) = a
+
+-- | Grab '_awKeepSize' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awsize' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepSize (c :: Axi4WriteAddressConfig) where
+  AWKeepSize ('Axi4WriteAddressConfig _ a _ _ _ _ _ _ _ _) = a
+
+-- | Grab '_awIdWidth' from 'Axi4WriteAddressConfig' at the type level.
+-- This nat value determines the size of the '_awid' field
+-- in 'M2S_WriteAddress'.
+type family AWIdWidth (c :: Axi4WriteAddressConfig) where
+  AWIdWidth ('Axi4WriteAddressConfig _ _ a _ _ _ _ _ _ _) = a
+
+-- | Grab '_awAddrWidth' from 'Axi4WriteAddressConfig' at the type level.
+-- This nat value determines the size of the '_awaddr' field
+-- in 'M2S_WriteAddress'.
+type family AWAddrWidth (c :: Axi4WriteAddressConfig) where
+  AWAddrWidth ('Axi4WriteAddressConfig _ _ _ a _ _ _ _ _ _) = a
+
+-- | Grab '_awKeepRegion' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awregion' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepRegion (c :: Axi4WriteAddressConfig) where
+  AWKeepRegion ('Axi4WriteAddressConfig _ _ _ _ a _ _ _ _ _) = a
+
+-- | Grab '_awKeepBurstLength' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awlen' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepBurstLength (c :: Axi4WriteAddressConfig) where
+  AWKeepBurstLength ('Axi4WriteAddressConfig _ _ _ _ _ a _ _ _ _) = a
+
+-- | Grab '_awKeepLock' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awlock' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepLock (c :: Axi4WriteAddressConfig) where
+  AWKeepLock ('Axi4WriteAddressConfig _ _ _ _ _ _ a _ _ _) = a
+
+-- | Grab '_awKeepCache' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awcache' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepCache (c :: Axi4WriteAddressConfig) where
+  AWKeepCache ('Axi4WriteAddressConfig _ _ _ _ _ _ _ a _ _) = a
+
+-- | Grab '_awKeepPermissions' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awprot' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepPermissions (c :: Axi4WriteAddressConfig) where
+  AWKeepPermissions ('Axi4WriteAddressConfig _ _ _ _ _ _ _ _ a _) = a
+
+-- | Grab '_awKeepQos' from 'Axi4WriteAddressConfig' at the type level.
+-- This boolean value determines whether to keep the '_awqos' field
+-- in 'M2S_WriteAddress'.
+type family AWKeepQos (c :: Axi4WriteAddressConfig) where
+  AWKeepQos ('Axi4WriteAddressConfig _ _ _ _ _ _ _ _ _ a) = a
+
 -- | AXI4 Write Address channel protocol
 data Axi4WriteAddress
   (dom :: C.Domain)
-  (kb :: KeepBurst)
-  (ksz :: KeepSize)
-  (lw :: LengthWidth)
-  (iw :: IdWidth)
-  (aw :: AddrWidth)
-  (kr :: KeepRegion)
-  (kbl :: KeepBurstLength)
-  (kl :: KeepLock)
-  (kc :: KeepCache)
-  (kp :: KeepPermissions)
-  (kq :: KeepQos)
+  (conf :: Axi4WriteAddressConfig)
   (userType :: Type)
 
-instance Protocol (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
-  type Fwd (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
-    C.Signal dom (M2S_WriteAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
-  type Bwd (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
+instance Protocol (Axi4WriteAddress dom conf userType) where
+  type Fwd (Axi4WriteAddress dom conf userType) =
+    C.Signal dom (M2S_WriteAddress conf userType)
+  type Bwd (Axi4WriteAddress dom conf userType) =
     C.Signal dom S2M_WriteAddress
 
-instance Backpressure (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
+instance Backpressure (Axi4WriteAddress dom conf userType) where
   boolsToBwd _ = C.fromList_lazy . coerce
 
-instance DfLike dom (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType where
-  type Data (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType =
-    M2S_WriteAddress kb ksz lw iw aw kr kbl kl kc kp kq userType
+instance DfLike dom (Axi4WriteAddress dom conf) userType where
+  type Data (Axi4WriteAddress dom conf) userType =
+    M2S_WriteAddress conf userType
 
   type Payload userType = userType
 
-  type Ack (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) userType =
+  type Ack (Axi4WriteAddress dom conf) userType =
     S2M_WriteAddress
 
   getPayload _ (M2S_WriteAddress{_awuser}) = Just _awuser
@@ -84,15 +162,15 @@ instance DfLike dom (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq) us
   {-# INLINE ackToBool #-}
 
 instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType) =>
-  Simulate (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) where
+  Simulate (Axi4WriteAddress dom conf userType) where
 
-  type SimulateFwdType (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
-    [M2S_WriteAddress kb ksz lw iw aw kr kbl kl kc kp kq userType]
+  type SimulateFwdType (Axi4WriteAddress dom conf userType) =
+    [M2S_WriteAddress conf userType]
 
-  type SimulateBwdType (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) =
+  type SimulateBwdType (Axi4WriteAddress dom conf userType) =
     [S2M_WriteAddress]
 
-  type SimulateChannels (Axi4WriteAddress dom kb ksz lw iw aw kr kbl kl kc kp kq userType) = 1
+  type SimulateChannels (Axi4WriteAddress dom conf userType) = 1
 
   simToSigFwd Proxy = C.fromList_lazy
   simToSigBwd Proxy = C.fromList_lazy
@@ -104,49 +182,39 @@ instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType
 
 -- | See Table A2-2 "Write address channel signals"
 data M2S_WriteAddress
-  (kb :: KeepBurst)
-  (ksz :: KeepSize)
-  (lw :: LengthWidth)
-  (iw :: IdWidth)
-  (aw :: AddrWidth)
-  (kr :: KeepRegion)
-  (kbl :: KeepBurstLength)
-  (kl :: KeepLock)
-  (kc :: KeepCache)
-  (kp :: KeepPermissions)
-  (kq :: KeepQos)
+  (conf :: Axi4WriteAddressConfig)
   (userType :: Type)
   = M2S_NoWriteAddress
   | M2S_WriteAddress
     { -- | Write address id*
-      _awid :: !(C.BitVector (Width iw))
+      _awid :: !(C.BitVector (AWIdWidth conf))
 
       -- | Write address
-    , _awaddr :: !(C.BitVector (Width aw))
+    , _awaddr :: !(C.BitVector (AWAddrWidth conf))
 
       -- | Write region*
-    , _awregion:: !(RegionType kr)
+    , _awregion:: !(RegionType (AWKeepRegion conf))
 
       -- | Burst length*
-    , _awlen :: !(BurstLengthType kbl)
+    , _awlen :: !(BurstLengthType (AWKeepBurstLength conf))
 
       -- | Burst size*
-    , _awsize :: !(SizeType ksz)
+    , _awsize :: !(SizeType (AWKeepSize conf))
 
       -- | Burst type*
-    , _awburst :: !(BurstType kb)
+    , _awburst :: !(BurstType (AWKeepBurst conf))
 
       -- | Lock type*
-    , _awlock :: !(LockType kl)
+    , _awlock :: !(LockType (AWKeepLock conf))
 
       -- | Cache type*
-    , _awcache :: !(CacheType kc)
+    , _awcache :: !(CacheType (AWKeepCache conf))
 
       -- | Protection type
-    , _awprot :: !(PermissionsType kp)
+    , _awprot :: !(PermissionsType (AWKeepPermissions conf))
 
       -- | QoS value
-    , _awqos :: !(QosType kq)
+    , _awqos :: !(QosType (AWKeepQos conf))
 
       -- | User data
     , _awuser :: !userType
@@ -157,49 +225,96 @@ data M2S_WriteAddress
 newtype S2M_WriteAddress = S2M_WriteAddress { _awready :: Bool }
   deriving (Show, Generic, C.NFDataX)
 
-deriving instance
-  ( C.KnownNat (Width iw)
-  , C.KnownNat (Width aw)
-  , Show (SizeType ksz)
-  , Show (BurstType kb)
-  , Show userType
-  , Show (RegionType kr)
-  , Show (BurstLengthType kbl)
-  , Show (LockType kl)
-  , Show (CacheType kc)
-  , Show (PermissionsType kp)
-  , Show (QosType kq)
-  ) =>
-  Show (M2S_WriteAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
+-- | Shorthand for a "well-behaved" write address config,
+-- so that we don't need to write out a bunch of type constraints later.
+-- Holds for every configuration; don't worry about implementing this class.
+class
+  ( KeepTypeClass (AWKeepBurst conf)
+  , KeepTypeClass (AWKeepSize conf)
+  , KeepTypeClass (AWKeepRegion conf)
+  , KeepTypeClass (AWKeepBurstLength conf)
+  , KeepTypeClass (AWKeepLock conf)
+  , KeepTypeClass (AWKeepCache conf)
+  , KeepTypeClass (AWKeepPermissions conf)
+  , KeepTypeClass (AWKeepQos conf)
+
+  , C.KnownNat (AWIdWidth conf)
+  , C.KnownNat (AWAddrWidth conf)
+
+  , Show (RegionType (AWKeepRegion conf))
+  , Show (BurstLengthType (AWKeepBurstLength conf))
+  , Show (SizeType (AWKeepSize conf))
+  , Show (BurstType (AWKeepBurst conf))
+  , Show (LockType (AWKeepLock conf))
+  , Show (CacheType (AWKeepCache conf))
+  , Show (PermissionsType (AWKeepPermissions conf))
+  , Show (QosType (AWKeepQos conf))
+
+  , C.NFDataX (RegionType (AWKeepRegion conf))
+  , C.NFDataX (BurstLengthType (AWKeepBurstLength conf))
+  , C.NFDataX (SizeType (AWKeepSize conf))
+  , C.NFDataX (BurstType (AWKeepBurst conf))
+  , C.NFDataX (LockType (AWKeepLock conf))
+  , C.NFDataX (CacheType (AWKeepCache conf))
+  , C.NFDataX (PermissionsType (AWKeepPermissions conf))
+  , C.NFDataX (QosType (AWKeepQos conf))
+  ) => GoodAxi4WriteAddressConfig conf
+
+instance
+  ( KeepTypeClass (AWKeepBurst conf)
+  , KeepTypeClass (AWKeepSize conf)
+  , KeepTypeClass (AWKeepRegion conf)
+  , KeepTypeClass (AWKeepBurstLength conf)
+  , KeepTypeClass (AWKeepLock conf)
+  , KeepTypeClass (AWKeepCache conf)
+  , KeepTypeClass (AWKeepPermissions conf)
+  , KeepTypeClass (AWKeepQos conf)
+
+  , C.KnownNat (AWIdWidth conf)
+  , C.KnownNat (AWAddrWidth conf)
+
+  , Show (RegionType (AWKeepRegion conf))
+  , Show (BurstLengthType (AWKeepBurstLength conf))
+  , Show (SizeType (AWKeepSize conf))
+  , Show (BurstType (AWKeepBurst conf))
+  , Show (LockType (AWKeepLock conf))
+  , Show (CacheType (AWKeepCache conf))
+  , Show (PermissionsType (AWKeepPermissions conf))
+  , Show (QosType (AWKeepQos conf))
+
+  , C.NFDataX (RegionType (AWKeepRegion conf))
+  , C.NFDataX (BurstLengthType (AWKeepBurstLength conf))
+  , C.NFDataX (SizeType (AWKeepSize conf))
+  , C.NFDataX (BurstType (AWKeepBurst conf))
+  , C.NFDataX (LockType (AWKeepLock conf))
+  , C.NFDataX (CacheType (AWKeepCache conf))
+  , C.NFDataX (PermissionsType (AWKeepPermissions conf))
+  , C.NFDataX (QosType (AWKeepQos conf))
+  ) => GoodAxi4WriteAddressConfig conf
 
 deriving instance
-  ( C.NFDataX userType
-  , C.NFDataX (BurstType kb)
-  , C.NFDataX (SizeType ksz)
-  , C.NFDataX (BurstType kb)
-  , C.NFDataX userType
-  , C.NFDataX (RegionType kr)
-  , C.NFDataX (BurstLengthType kbl)
-  , C.NFDataX (LockType kl)
-  , C.NFDataX (CacheType kc)
-  , C.NFDataX (PermissionsType kp)
-  , C.NFDataX (QosType kq)
-  , C.KnownNat (Width iw)
-  , C.KnownNat (Width aw)
+  ( GoodAxi4WriteAddressConfig conf
+  , Show userType
   ) =>
-  C.NFDataX (M2S_WriteAddress kb ksz lw iw aw kr kbl kl kc kp kq userType)
+  Show (M2S_WriteAddress conf userType)
+
+deriving instance
+  ( GoodAxi4WriteAddressConfig conf
+  , C.NFDataX userType
+  ) =>
+  C.NFDataX (M2S_WriteAddress conf userType)
 
 -- | Circuit that transforms the LHS 'Axi4WriteAddress' protocol to a
 -- version using different type parameters according to two functions
 -- that can transform the data and ack signal to and from the other protocol.
 mapFull ::
   forall dom
-    kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 userType1
-    kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 userType2 .
-  (M2S_WriteAddress kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 userType1 ->
-    M2S_WriteAddress kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 userType2) ->
+    conf1 userType1
+    conf2 userType2 .
+  (M2S_WriteAddress conf1 userType1 ->
+    M2S_WriteAddress conf2 userType2) ->
   (S2M_WriteAddress -> S2M_WriteAddress) ->
   Circuit
-    (Axi4WriteAddress dom kb1 ksz1 lw1 iw1 aw1 kr1 kbl1 kl1 kc1 kp1 kq1 userType1)
-    (Axi4WriteAddress dom kb2 ksz2 lw2 iw2 aw2 kr2 kbl2 kl2 kc2 kp2 kq2 userType2)
+    (Axi4WriteAddress dom conf1 userType1)
+    (Axi4WriteAddress dom conf2 userType2)
 mapFull = DfLike.mapDfLike Proxy Proxy

--- a/src/Protocols/Axi4/WriteResponse.hs
+++ b/src/Protocols/Axi4/WriteResponse.hs
@@ -15,6 +15,12 @@ module Protocols.Axi4.WriteResponse
   , S2M_WriteResponse(..)
   , Axi4WriteResponse
   , mapFull
+
+    -- * configuration
+  , Axi4WriteResponseConfig(..)
+  , GoodAxi4WriteResponseConfig
+  , BKeepResponse
+  , BIdWidth
   ) where
 
 -- base
@@ -32,29 +38,46 @@ import Protocols.Internal
 import Protocols.DfLike (DfLike)
 import qualified Protocols.DfLike as DfLike
 
+-- | Configuration options for 'Axi4WriteResponse'.
+data Axi4WriteResponseConfig = Axi4WriteResponseConfig
+  { _bKeepResponse :: Bool
+  , _bIdWidth      :: C.Nat
+  }
+
+-- | Grab '_bKeepResponse' from 'Axi4WriteResponseConfig' at the type level.
+-- This boolean value determines whether to keep the '_bresp' field
+-- in 'S2M_WriteResponse'.
+type family BKeepResponse (conf :: Axi4WriteResponseConfig) where
+  BKeepResponse ('Axi4WriteResponseConfig a _) = a
+
+-- | Grab '_bIdWidth' from 'Axi4WriteResponseConfig' at the type level.
+-- This nat value determines the size of the '_bid' field
+-- in 'S2M_WriteResponse'.
+type family BIdWidth (conf :: Axi4WriteResponseConfig) where
+  BIdWidth ('Axi4WriteResponseConfig _ a) = a
+
 -- | AXI4 Read Data channel protocol
 data Axi4WriteResponse
   (dom :: C.Domain)
-  (kr :: KeepResponse)
-  (iw :: IdWidth)
+  (conf :: Axi4WriteResponseConfig)
   (userType :: Type)
 
-instance Protocol (Axi4WriteResponse dom kr iw userType) where
-  type Fwd (Axi4WriteResponse dom kr iw userType) =
-    C.Signal dom (S2M_WriteResponse kr iw userType)
-  type Bwd (Axi4WriteResponse dom kr iw userType) =
+instance Protocol (Axi4WriteResponse dom conf userType) where
+  type Fwd (Axi4WriteResponse dom conf userType) =
+    C.Signal dom (S2M_WriteResponse conf userType)
+  type Bwd (Axi4WriteResponse dom conf userType) =
     C.Signal dom M2S_WriteResponse
 
-instance Backpressure (Axi4WriteResponse dom kr iw userType) where
+instance Backpressure (Axi4WriteResponse dom conf userType) where
   boolsToBwd _ = C.fromList_lazy . coerce
 
-instance DfLike dom (Axi4WriteResponse dom kr iw) userType where
-  type Data (Axi4WriteResponse dom kr iw) userType =
-    S2M_WriteResponse kr iw userType
+instance DfLike dom (Axi4WriteResponse dom conf) userType where
+  type Data (Axi4WriteResponse dom conf) userType =
+    S2M_WriteResponse conf userType
 
   type Payload userType = userType
 
-  type Ack (Axi4WriteResponse dom kr iw) userType =
+  type Ack (Axi4WriteResponse dom conf) userType =
     M2S_WriteResponse
 
   getPayload _ (S2M_WriteResponse{_buser}) = Just _buser
@@ -75,15 +98,15 @@ instance DfLike dom (Axi4WriteResponse dom kr iw) userType where
   {-# INLINE ackToBool #-}
 
 instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType) =>
-  Simulate (Axi4WriteResponse dom kr iw userType) where
+  Simulate (Axi4WriteResponse dom conf userType) where
 
-  type SimulateFwdType (Axi4WriteResponse dom kr iw userType) =
-    [S2M_WriteResponse kr iw userType]
+  type SimulateFwdType (Axi4WriteResponse dom conf userType) =
+    [S2M_WriteResponse conf userType]
 
-  type SimulateBwdType (Axi4WriteResponse dom kr iw userType) =
+  type SimulateBwdType (Axi4WriteResponse dom conf userType) =
     [M2S_WriteResponse]
 
-  type SimulateChannels (Axi4WriteResponse dom kr iw userType) = 1
+  type SimulateChannels (Axi4WriteResponse dom conf userType) = 1
 
   simToSigFwd Proxy = C.fromList_lazy
   simToSigBwd Proxy = C.fromList_lazy
@@ -95,16 +118,15 @@ instance (C.KnownDomain dom, C.NFDataX userType, C.ShowX userType, Show userType
 
 -- | See Table A2-4 "Write response channel signals"
 data S2M_WriteResponse
-  (kr :: KeepResponse)
-  (iw :: IdWidth)
+  (conf :: Axi4WriteResponseConfig)
   (userType :: Type)
   = S2M_NoWriteResponse
   | S2M_WriteResponse
     { -- | Response ID
-      _bid :: !(C.BitVector (Width iw))
+      _bid :: !(C.BitVector (BIdWidth conf))
 
       -- | Write response
-    , _bresp :: !(ResponseType kr)
+    , _bresp :: !(ResponseType (BKeepResponse conf))
 
       -- | User data
     , _buser :: !userType
@@ -115,28 +137,45 @@ data S2M_WriteResponse
 newtype M2S_WriteResponse = M2S_WriteResponse { _bready :: Bool }
   deriving (Show, Generic, C.NFDataX)
 
-deriving instance
-  ( C.NFDataX userType
-  , C.NFDataX (ResponseType kr)
-  , C.KnownNat (Width iw) ) =>
-  C.NFDataX (S2M_WriteResponse kr iw userType)
+-- | Shorthand for a "well-behaved" write response config,
+-- so that we don't need to write out a bunch of type constraints later.
+-- Holds for every configuration; don't worry about implementing this class.
+class
+  ( KeepTypeClass (BKeepResponse conf)
+  , C.KnownNat (BIdWidth conf)
+  , Show (ResponseType (BKeepResponse conf))
+  , C.NFDataX (ResponseType (BKeepResponse conf))
+  ) => GoodAxi4WriteResponseConfig conf
+
+instance
+  ( KeepTypeClass (BKeepResponse conf)
+  , C.KnownNat (BIdWidth conf)
+  , Show (ResponseType (BKeepResponse conf))
+  , C.NFDataX (ResponseType (BKeepResponse conf))
+  ) => GoodAxi4WriteResponseConfig conf
 
 deriving instance
-  ( Show userType
-  , Show (ResponseType kr)
-  , C.KnownNat (Width iw) ) =>
-  Show (S2M_WriteResponse kr iw userType)
+  ( GoodAxi4WriteResponseConfig conf
+  , Show userType
+  ) =>
+  Show (S2M_WriteResponse conf userType)
+
+deriving instance
+  ( GoodAxi4WriteResponseConfig conf
+  , C.NFDataX userType
+  ) =>
+  C.NFDataX (S2M_WriteResponse conf userType)
 
 -- | Circuit that transforms the LHS 'Axi4WriteResponse' protocol to a
 -- version using different type parameters according to two functions
 -- that can transform the data and ack signal to and from the other protocol.
 mapFull ::
   forall dom
-    kr1 iw1 userType1
-    kr2 iw2 userType2 .
-  (S2M_WriteResponse kr1 iw1 userType1 -> S2M_WriteResponse kr2 iw2 userType2) ->
+    conf1 userType1
+    conf2 userType2 .
+  (S2M_WriteResponse conf1 userType1 -> S2M_WriteResponse conf2 userType2) ->
   (M2S_WriteResponse -> M2S_WriteResponse) ->
   Circuit
-    (Axi4WriteResponse dom kr1 iw1 userType1)
-    (Axi4WriteResponse dom kr2 iw2 userType2)
+    (Axi4WriteResponse dom conf1 userType1)
+    (Axi4WriteResponse dom conf2 userType2)
 mapFull = DfLike.mapDfLike Proxy Proxy


### PR DESCRIPTION
This PR refactors AXI4 types so that they each only need one config type variable. This variable is a struct containing all of the `Bool` and `Nat` values that used to be passed around individually. It also adds a way to grab optional fields polymorphically as a `Maybe` value (`Nothing` if the field is turned off, `Just value` if the field is turned on).