### PR TITLE
Half-finished tries at making avalon memory mapped interconnect fabric

### DIFF
--- a/tests/Tests/Protocols/AvalonMemMap.hs
+++ b/tests/Tests/Protocols/AvalonMemMap.hs
@@ -150,6 +150,36 @@ prop_avalon_convert_subordinate_manager_rev =
     (AvalonMmManager dom ManagerConfig)
   ckt = DfConv.convert Proxy Proxy
 
+prop_interconnect_fabric_id :: Property
+prop_interconnect_fabric_id =
+  DfTest.idWithModelDf
+    defExpectOptions
+    (DfTest.genData $ (Left <$> genReadReqImpt) C.<|> (Right <$> genWriteImpt))
+    id
+    ( C.withClockResetEnable @C.System C.clockGen C.resetGen C.enableGen
+    $ DfConv.dfConvTestBench Proxy Proxy (repeat True)
+      (repeat (Df.Data readImpt)) ckt)
+ where
+  ckt :: (C.HiddenClockResetEnable dom) => Circuit
+    (AvalonMmManager dom ManagerConfig)
+    (AvalonMmSubordinate dom 0 SubordinateConfig)
+  ckt = interconnectFabricSingleMember (const True) 0 C.SNat
+
+prop_interconnect_fabric_2_id :: Property
+prop_interconnect_fabric_2_id =
+  DfTest.idWithModelDf
+    defExpectOptions
+    (DfTest.genData $ (Left <$> genReadReqImpt) C.<|> (Right <$> genWriteImpt))
+    id
+    ( C.withClockResetEnable @C.System C.clockGen C.resetGen C.enableGen
+    $ DfConv.dfConvTestBench Proxy Proxy (repeat True)
+      (repeat (Df.Data readImpt)) ckt)
+ where
+  ckt :: (C.HiddenClockResetEnable dom) => Circuit
+    (AvalonMmManager dom ManagerConfig)
+    (AvalonMmSubordinate dom 0 SubordinateConfig)
+  ckt = interconnectFabric2SingleMember (const $ Just 0)
+
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
This PR contains 2 of my attempts at making an interconnect fabric for avalon memory mapped, which turned out to be harder than expected. Hopefully they can be of use if anyone plans on implementing the interconnect fabric. The first one is mostly finished, although it's pretty long and I can't vouch for its correctness. It currently doesn't pass tests (for some reason; it used to). It also doesn't include support for the flush signal. The second one is based on `DfConv` and will work correctly for Avalon Memory Mapped configurations that only include DfConv-compatible signals. It passes tests. I was partway through adding support for the IRQ signal as well. Currently it has no support for the BeginTransfer, BeginBurstTransfer, or flush signals.