### PR TITLE
add 'common sense' wishbone validation

### DIFF
--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -132,7 +132,6 @@ library
     , hedgehog >= 1.0.2
     , pretty-show
     , strict-tuple
-
     , mtl
     , hashable
 

--- a/src/Protocols/Wishbone/Standard.hs
+++ b/src/Protocols/Wishbone/Standard.hs
@@ -128,7 +128,7 @@ memoryWb ram = Circuit go
     Signal dom (WishboneM2S addressWidth (BitSize a `DivRU` 8) a) ->
     Signal dom (WishboneS2M a)
   reply request = do
-    ack <- (writeAck .||. readAck) .&&. (not <$> isError)
+    ack <- (writeAck .||. readAck) .&&. (not <$> isError) .&&. requestValid
     errVal <- isError
     val <- readValue
     pure $ (emptyWishboneS2M @a) {acknowledge = ack, err = errVal, readData = val}

--- a/src/Protocols/Wishbone/Standard/Hedgehog.hs
+++ b/src/Protocols/Wishbone/Standard/Hedgehog.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Types and functions to aid with testing Wishbone circuits.
@@ -11,7 +13,7 @@ module Protocols.Wishbone.Standard.Hedgehog
   )
 where
 
-import Clash.Prelude as C hiding (cycle, not, (&&), (||))
+import Clash.Prelude as C hiding (cycle, not, (&&), (||), indices)
 import Clash.Signal.Internal (Signal ((:-)))
 -- hedgehog
 import Control.DeepSeq (NFData)
@@ -25,63 +27,184 @@ import Protocols hiding (stallC, circuit)
 import Protocols.Hedgehog
 import Protocols.Wishbone
 import Prelude as P hiding (cycle)
+import Clash.Sized.Internal.BitVector
 
 -- | Datatype representing a single transaction request sent from a Wishbone Master to a Wishbone Slave
 data WishboneMasterRequest addressWidth dat
-  = Read (BitVector addressWidth)
-  | Write (BitVector addressWidth) dat
-  deriving (Show)
+  = Read (BitVector addressWidth) (BitVector (BitSize dat `DivRU` 8))
+  | Write (BitVector addressWidth) (BitVector (BitSize dat `DivRU` 8)) dat
 
-data WishboneStandardState
-  = WSSQuiet
-  | WSSInCycleNoStrobe
-  | WSSWaitForSlave
+deriving instance (KnownNat addressWidth, KnownNat (BitSize a), Show a) => (Show (WishboneMasterRequest addressWidth a))
+
+--
+-- Validation for (lenient) spec compliance
+--
+-- The Wishbone spec mostly specifies the handshake protocols but does not make many
+-- assumptions about which signals *should* be valid in response to what. This is
+-- presumably done so to allow circuits to be very flexible, however it makes for
+-- a relatively weak validation tool.
+--
+
+data LenientValidationState
+  = LVSQuiet
+  | LVSInCycleNoStrobe
+  | LVSWaitForSlave
 
 -- TODO add a SlaveHolding state? Spec seems unclear
 
-data WishboneStandardError
-  = WSEMoreThanOneTerminationSignalAsserted
-  | WSETerminationSignalOutsideOfCycle
+data LenientValidationError
+  = LVEMoreThanOneTerminationSignalAsserted
+  | LVETerminationSignalOutsideOfCycle
   deriving (NFData, Generic, NFDataX, Show, ShowX, Eq)
 
-nextStateStandard ::
-  WishboneStandardState ->
+nextStateLenient ::
+  LenientValidationState ->
   WishboneM2S addressWidth (BitSize a `DivRU` 8) a ->
   WishboneS2M a ->
-  Either WishboneStandardError WishboneStandardState
-nextStateStandard _ m2s s2m
+  Either LenientValidationError LenientValidationState
+nextStateLenient _ m2s s2m
   | P.length (filter ($ s2m) [acknowledge, err, retry]) > 1 =
-    Left WSEMoreThanOneTerminationSignalAsserted
+    Left LVEMoreThanOneTerminationSignalAsserted
   | not (busCycle m2s) && (acknowledge s2m || err s2m || retry s2m) =
-    Left WSETerminationSignalOutsideOfCycle
-nextStateStandard WSSQuiet m2s _
-  | busCycle m2s && P.not (strobe m2s) = Right WSSInCycleNoStrobe
-  | busCycle m2s && strobe m2s = Right WSSWaitForSlave
-  | otherwise = Right WSSQuiet
-nextStateStandard WSSInCycleNoStrobe m2s _
-  | not (busCycle m2s) = Right WSSQuiet
-  | busCycle m2s && strobe m2s = Right WSSWaitForSlave
-  | otherwise = Right WSSInCycleNoStrobe
-nextStateStandard WSSWaitForSlave m2s s2m
-  | busCycle m2s && P.not (strobe m2s) = Right WSSInCycleNoStrobe
-  | not (busCycle m2s) = Right WSSQuiet
-  | acknowledge s2m || err s2m || retry s2m = Right WSSQuiet
-  | otherwise = Right WSSWaitForSlave
+    Left LVETerminationSignalOutsideOfCycle
+nextStateLenient LVSQuiet m2s _
+  | busCycle m2s && P.not (strobe m2s) = Right LVSInCycleNoStrobe
+  | busCycle m2s && strobe m2s = Right LVSWaitForSlave
+  | otherwise = Right LVSQuiet
+nextStateLenient LVSInCycleNoStrobe m2s _
+  | not (busCycle m2s) = Right LVSQuiet
+  | busCycle m2s && strobe m2s = Right LVSWaitForSlave
+  | otherwise = Right LVSInCycleNoStrobe
+nextStateLenient LVSWaitForSlave m2s s2m
+  | busCycle m2s && P.not (strobe m2s) = Right LVSInCycleNoStrobe
+  | not (busCycle m2s) = Right LVSQuiet
+  | acknowledge s2m || err s2m || retry s2m = Right LVSQuiet
+  | otherwise = Right LVSWaitForSlave
 
--- | Validate the input/output streams of a standard wishbone interface
+-- | Lenient validation of a wishbone-component based on the specification
 --
 -- Returns 'Right ()' when the interactions comply with the spec.
 -- Returns 'Left (cycle, err)' when a spec violation was found.
-validateStandard ::
+validateLenient ::
   [WishboneM2S addressWidth (BitSize a `DivRU` 8) a] ->
   [WishboneS2M a] ->
-  Either (Int, WishboneStandardError) ()
-validateStandard m2s s2m = go 0 (P.zip m2s s2m) WSSQuiet
+  Either (Int, LenientValidationError) ()
+validateLenient m2s s2m = go 0 (P.zip m2s s2m) LVSQuiet
   where
     go _ [] _ = Right ()
-    go n ((fwd, bwd) : rest) st0 = case nextStateStandard st0 fwd bwd of
+    go n ((fwd, bwd) : rest) st = case nextStateLenient st fwd bwd of
       Left e -> Left (n, e)
-      Right st1 -> go (n + 1) rest st1
+      Right st' -> go (n + 1) rest st'
+
+--
+-- Validation for "common sense" compliance
+--
+-- The Wishbone spec itself makes very little assumptions about how interactions
+-- should look like outside of basic hand-shaking.
+-- This "common sense" compliance checking additionally checks for:
+--  - A read request is acked with defined data
+--    - response data respects the 'busSelect' signal
+--  - A write request is answered with only an ACK/ERR/RETRY and no defined data
+--    - components might want to reply with data
+--
+
+type CommonSenseValidationError = String
+
+data CommonSenseValidationState
+  = CSVSQuiet
+  | CSVSInCycleNoStrobe
+  | CSVSReadCycle
+  | CSVSWriteCycle
+  deriving (Eq, Show)
+
+nextStateCommonSense ::
+  forall a addressWidth.
+  (BitPack a) =>
+  CommonSenseValidationState ->
+  WishboneM2S addressWidth (BitSize a `DivRU` 8) a ->
+  WishboneS2M a ->
+  Either CommonSenseValidationError (Bool, CommonSenseValidationState)
+--                                    ^ go to next cycle
+nextStateCommonSense _ _ s2m
+  | P.length (filter ($ s2m) [acknowledge, err, retry]) > 1 =
+    Left "More than one termination signal asserted"
+nextStateCommonSense CSVSQuiet WishboneM2S {..} s2m
+  | busCycle && not strobe = Right (True, CSVSInCycleNoStrobe)
+  | busCycle && strobe && writeEnable = Right (False, CSVSWriteCycle)
+  | busCycle && strobe && not writeEnable = Right (False, CSVSReadCycle)
+  | hasTerminateFlag s2m = Left "Termination signals outside of a bus cycle"
+  | otherwise = Right (True, CSVSQuiet)
+nextStateCommonSense CSVSInCycleNoStrobe WishboneM2S {..} _
+  | not busCycle = Right (True, CSVSQuiet)
+  | not strobe = Right (True, CSVSInCycleNoStrobe)
+  | writeEnable = Right (False, CSVSWriteCycle)
+  | not writeEnable = Right (False, CSVSReadCycle)
+  | otherwise = C.error "Should not happen"
+nextStateCommonSense CSVSReadCycle m2s@WishboneM2S {..} s2m@WishboneS2M {..}
+  | not busCycle = Right (True, CSVSQuiet)
+  | not strobe = Right (True, CSVSInCycleNoStrobe)
+  | acknowledge =
+    if responseValid m2s s2m
+      then Right (True, CSVSQuiet)
+      else Left "read-response does not respect SEL"
+  | err || retry = Right (True, CSVSQuiet)
+  | writeEnable = Left "asserted WE while in a read cycle"
+  | otherwise = Right (True, CSVSReadCycle)
+  where
+    responseValid WishboneM2S {busSelect=sel} WishboneS2M {readData=dat} = selectValidData sel dat
+nextStateCommonSense CSVSWriteCycle m2s@WishboneM2S {..} s2m@WishboneS2M {..}
+  | not busCycle = Right (True, CSVSQuiet)
+  | not strobe = Right (True, CSVSInCycleNoStrobe)
+  | not writeEnable = Left "deasserted WE while in a write cycle"
+  | not $ requestValid m2s = Left "write request does not respect SEL"
+  | err || retry = Right (True, CSVSQuiet)
+  | acknowledge =
+    if responseValid s2m
+      then Right (True, CSVSQuiet)
+      else Left "write-response contains defined read-data"
+  | otherwise = Right (True, CSVSWriteCycle)
+  where
+    requestValid WishboneM2S {busSelect=sel, writeData=dat} = selectValidData sel dat
+    responseValid WishboneS2M {readData=dat0} =
+      let dat1 = bitCoerce dat0
+          numBits = natVal @_ @BitVector dat1
+          mask = 2 P.^ numBits - 1
+       in unsafeMask dat1 == mask
+
+selectValidData ::
+  forall a.
+  (KnownNat (BitSize a), BitPack a) =>
+  BitVector (BitSize a `DivRU` 8) ->
+  a ->
+  Bool
+selectValidData byteSelect rawDat =
+  all
+    (== False)
+    [ hasUndefined part
+      | idx <- indices byteSelect,
+        let part = dat ! idx
+    ]
+  where
+    dat :: C.Vec (BitSize a `DivRU` 8) (BitVector 8)
+    dat = case maybeIsX rawDat of
+      Just val -> bitCoerce $ resize (bitCoerce val :: BitVector (BitSize a))
+      Nothing -> C.repeat undefined#
+
+    indices :: forall n. (KnownNat n) => BitVector n -> [Index n]
+    indices bv = [idx | idx <- [0 .. maxBound], bitToBool (bv ! idx)]
+
+validateCommonSense ::
+  (BitPack a) =>
+  [WishboneM2S addressWidth (BitSize a `DivRU` 8) a] ->
+  [WishboneS2M a] ->
+  Either (Int, CommonSenseValidationError) ()
+validateCommonSense m2s s2m = go 0 (P.zip m2s s2m) CSVSQuiet
+  where
+    go _ [] _ = Right ()
+    go n ((fwd, bwd) : rest) st = case nextStateCommonSense st fwd bwd of
+      Left e -> Left (n, e)
+      Right (False, st') -> go (n + 1) ((fwd, bwd) : rest) st'
+      Right (True, st') -> go (n + 1) rest st'
 
 -- | Create a stalling wishbone 'Standard' circuit.
 stallStandard ::
@@ -204,18 +327,20 @@ driveStandard ExpectOptions {..} reqs =
       ) =>
       WishboneMasterRequest addrWidth b ->
       WishboneM2S addrWidth (BitSize b `DivRU` 8) b
-    transferToSignals (Read addr) =
+    transferToSignals (Read addr sel) =
       (emptyWishboneM2S @addrWidth @b)
         { busCycle = True,
           strobe = True,
           addr = addr,
+          busSelect = sel,
           writeEnable = False
         }
-    transferToSignals (Write addr dat) =
+    transferToSignals (Write addr sel dat) =
       (emptyWishboneM2S @addrWidth @b)
         { busCycle = True,
           strobe = True,
           addr = addr,
+          busSelect = sel,
           writeEnable = True,
           writeData = dat
         }
@@ -248,7 +373,8 @@ wishbonePropWithModel ::
     C.NFDataX a,
     C.KnownNat addressWidth,
     C.KnownDomain dom,
-    C.KnownNat (C.BitSize a)
+    C.KnownNat (C.BitSize a),
+    C.BitPack a
   ) =>
   ExpectOptions ->
   -- | Check whether a S2M signal for a given request is matching a pure model using @st@
@@ -278,7 +404,8 @@ wishbonePropWithModel eOpts model circuit0 inputGen st = H.property $ do
     circuit1 = stallC |> circuit0
     (m2s, _ : s2m) = observeComposedWishboneCircuit (eoTimeout eOpts) driver circuit1
 
-  validateStandard m2s s2m === Right ()
+  validateLenient m2s s2m === Right ()
+  validateCommonSense m2s s2m === Right ()
 
   matchModel 0 s2m input st === Right ()
   where

--- a/tests/Tests/Protocols/Wishbone.hs
+++ b/tests/Tests/Protocols/Wishbone.hs
@@ -7,9 +7,9 @@
 module Tests.Protocols.Wishbone where
 
 import Clash.Hedgehog.Sized.BitVector
-import Clash.Prelude hiding ((&&))
+import Clash.Prelude hiding (not, (&&))
+-- tasty
 import Control.DeepSeq (NFData)
-import Data.Either (isLeft)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -34,59 +34,60 @@ genData :: Gen a -> Gen [a]
 genData = Gen.list (Range.linear 0 150)
 
 genWishboneTransfer ::
-  (KnownNat addressWidth) =>
+  (KnownNat addressWidth, KnownNat (BitSize a)) =>
   Gen a ->
   Gen (WishboneMasterRequest addressWidth a)
 genWishboneTransfer genA =
   Gen.choice
-    [ Read <$> genDefinedBitVector,
-      Write <$> genDefinedBitVector <*> genA
+    [ Read <$> genDefinedBitVector <*> genDefinedBitVector ,
+      Write <$> genDefinedBitVector <*> genDefinedBitVector <*> genA
     ]
 
 --
--- 'id' circuit
+-- 'addrReadId' circuit
 --
 
-idWriteWbSt ::
-  forall a dom addressWidth.
-  (BitPack a, NFDataX a) =>
-  Circuit (Wishbone dom 'Standard addressWidth a) ()
-idWriteWbSt = Circuit go
+addrReadIdWb ::
+  forall dom addressWidth.
+  (KnownNat addressWidth) =>
+  Circuit (Wishbone dom 'Standard addressWidth (BitVector addressWidth)) ()
+addrReadIdWb = Circuit go
   where
     go (m2s, ()) = (reply <$> m2s, ())
 
     reply WishboneM2S {..}
       | busCycle && strobe && writeEnable =
-        (emptyWishboneS2M @a)
+        emptyWishboneS2M { acknowledge = True }
+      | busCycle && strobe =
+        (emptyWishboneS2M @(BitVector addressWidth))
           { acknowledge = True,
-            readData = writeData
+            readData = addr
           }
-      | busCycle && strobe = emptyWishboneS2M {acknowledge = True}
       | otherwise = emptyWishboneS2M
 
-idWriteStModel ::
-  (NFData a, Eq a, ShowX a) =>
-  WishboneMasterRequest addressWidth a ->
-  WishboneS2M a ->
+addrReadIdWbModel ::
+  (KnownNat addressWidth) =>
+  WishboneMasterRequest addressWidth (BitVector addressWidth) ->
+  WishboneS2M (BitVector addressWidth) ->
   -- | pure state
   () ->
   Either String ()
-idWriteStModel (Read _) s@WishboneS2M {..} ()
-  | acknowledge && isLeft (hasX readData) = Right ()
+addrReadIdWbModel (Read addr _) s@WishboneS2M {..} ()
+  | acknowledge && hasX readData == Right addr = Right ()
   | otherwise =
-    Left $ "Read should have been acknowledged with no DAT " <> showX s
-idWriteStModel (Write _ a) s@WishboneS2M {..} ()
-  | acknowledge && hasX readData == Right a = Right ()
+    Left $ "Read should have been acknowledged with address as DAT " <> showX s
+addrReadIdWbModel Write {} s@WishboneS2M {..} ()
+  | acknowledge && hasUndefined readData = Right ()
   | otherwise =
-    Left $ "Write should have been acknowledged with write-data as DAT " <> showX s
+    Left $ "Write should have been acknowledged with no DAT " <> showX s
 
-prop_idWriteSt_model :: Property
-prop_idWriteSt_model =
+prop_addrReadIdWb_model :: Property
+prop_addrReadIdWb_model =
   wishbonePropWithModel @System
     defExpectOptions
-    idWriteStModel
-    idWriteWbSt
-    (genData $ genWishboneTransfer @10 genSmallInt)
+    addrReadIdWbModel
+    addrReadIdWb
+    (genData $ genWishboneTransfer @10 genDefinedBitVector)
     ()
 
 --
@@ -94,26 +95,39 @@ prop_idWriteSt_model =
 --
 
 memoryWbModel ::
-  (KnownNat addressWidth, Eq a, ShowX a, NFDataX a, NFData a, Default a) =>
+  ( KnownNat addressWidth,
+    Eq a,
+    ShowX a,
+    NFDataX a,
+    NFData a,
+    Default a,
+    KnownNat (BitSize a)
+  ) =>
   WishboneMasterRequest addressWidth a ->
   WishboneS2M a ->
   [(BitVector addressWidth, a)] ->
   Either String [(BitVector addressWidth, a)]
-memoryWbModel (Read addr) s st
-  = case lookup addr st of
-      Just x | readData s == x && acknowledge s -> Right st
-      Just x | otherwise ->
-        Left $
-          "Read from a known address did not yield the same value "
-            <> showX x
-            <> " : "
-            <> showX s
-      Nothing | acknowledge s && hasX (readData s) == Right def -> Right st
-      Nothing | otherwise ->
-        Left $
-          "Read from unknown address did no ACK with undefined result : "
-            <> showX s
-memoryWbModel (Write addr a) s st
+memoryWbModel (Read addr sel) s st
+  | sel /= maxBound && err s = Right st
+  | sel /= maxBound && not (err s) =
+    Left "Read with non maxBound SEL should cause ERR response"
+  | otherwise = case lookup addr st of
+    Just x | readData s == x && acknowledge s -> Right st
+    Just x | otherwise ->
+      Left $
+        "Read from a known address did not yield the same value "
+          <> showX x
+          <> " : "
+          <> showX s
+    Nothing | acknowledge s && hasX (readData s) == Right def -> Right st
+    Nothing | otherwise ->
+      Left $
+        "Read from unknown address did no ACK with undefined result : "
+          <> showX s
+memoryWbModel (Write addr sel a) s st
+  | sel /= maxBound && err s = Right st
+  | sel /= maxBound && not (err s) =
+    Left "Write with non maxBound SEL should cause ERR response"
   | acknowledge s = Right ((addr, a) : st)
   | otherwise = Left $ "Write should be acked : " <> showX s
 

--- a/tests/Tests/Protocols/Wishbone.hs
+++ b/tests/Tests/Protocols/Wishbone.hs
@@ -82,7 +82,7 @@ addrReadIdWbModel Write {} s@WishboneS2M {..} ()
     Left $ "Write should have been acknowledged with no DAT " <> showX s
 
 prop_addrReadIdWb_model :: Property
-prop_addrReadIdWb_model =
+prop_addrReadIdWb_model = withClockResetEnable clockGen resetGen enableGen $
   wishbonePropWithModel @System
     defExpectOptions
     addrReadIdWbModel

--- a/tests/Tests/Protocols/Wishbone.hs
+++ b/tests/Tests/Protocols/Wishbone.hs
@@ -8,7 +8,6 @@ module Tests.Protocols.Wishbone where
 
 import Clash.Hedgehog.Sized.BitVector
 import Clash.Prelude hiding (not, (&&))
--- tasty
 import Control.DeepSeq (NFData)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen


### PR DESCRIPTION
Renames internal "spec validation" to "lenient validation" and adds a "common sense validation" mode.

The common sense validation mode checks for assumptions that seem sensible but are not part of the Wishbone specification.