### PR TITLE
GHC 9.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
         clash:
           - "1.6.1"
         cabal:
-          - "3.2"
+          - "3.6"
         ghc:
           - "8.10.7"
+          - "9.0.2"
 
     env:
       clash_version: ${{ matrix.clash }}

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,8 @@
 packages:
   clash-protocols.cabal
 
+tests: True
+
 package clash-prelude
   -- 'large-tuples' generates tuple instances for various classes up to the
   -- GHC imposed maximum of 62 elements. This severely slows down compiling
@@ -9,12 +11,6 @@ package clash-prelude
   flags: -large-tuples
 
 source-repository-package
-    type: git
-    location: https://github.com/cchalmers/circuit-notation.git
-    tag: 2574640364eef12222517af059b9e4a7e6b503a7
-
-source-repository-package
-    type: git
-    location: https://github.com/martijnbastiaan/haskell-hedgehog.git
-    tag: f7d25b0a1927b7c06d69535d5dcfcade560ec624
-    subdir: hedgehog
+  type: git
+  location: https://github.com/cchalmers/circuit-notation.git
+  tag: 618e37578e699df235f2e7150108b6401731919b

--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -127,7 +127,7 @@ library
     , data-default
     , deepseq
     , extra
-    , ghc >= 8.6
+    , ghc >= 8.7
     , hashable
     , hedgehog >= 1.0.2
     , pretty-show
@@ -164,6 +164,7 @@ library
     Protocols.Hedgehog
     Protocols.Hedgehog.Internal
     Protocols.Internal
+
     Protocols.Plugin
 
     -- 'testProperty' is broken upstream, it reports wrong test names
@@ -218,4 +219,4 @@ test-suite doctests
     base,
     clash-protocols,
     process,
-    doctest >= 0.17 && < 0.18
+    doctest

--- a/src/Protocols/Avalon/MemMap.hs
+++ b/src/Protocols/Avalon/MemMap.hs
@@ -1225,8 +1225,8 @@ instance
 
   simToSigFwd _ = fromList_lazy
   simToSigBwd _ = fromList_lazy
-  sigToSimFwd _ = sample_lazy
-  sigToSimBwd _ = sample_lazy
+  sigToSimFwd _ s = sample_lazy s
+  sigToSimBwd _ s = sample_lazy s
 
   stallC conf (head -> (stallAck, stalls))
     = withClockResetEnable clockGen resetGen enableGen
@@ -1246,8 +1246,8 @@ instance
 
   simToSigFwd _ = fromList_lazy
   simToSigBwd _ = fromList_lazy
-  sigToSimFwd _ = sample_lazy
-  sigToSimBwd _ = sample_lazy
+  sigToSimFwd _ s = sample_lazy s
+  sigToSimBwd _ s = sample_lazy s
 
   stallC conf (head -> (stallAck, stalls))
     = withClockResetEnable clockGen resetGen enableGen

--- a/src/Protocols/Avalon/Stream.hs
+++ b/src/Protocols/Avalon/Stream.hs
@@ -189,8 +189,8 @@ instance
 
   simToSigFwd _ = fromList_lazy
   simToSigBwd _ = fromList_lazy
-  sigToSimFwd _ = sample_lazy
-  sigToSimBwd _ = sample_lazy
+  sigToSimFwd _ s = sample_lazy s
+  sigToSimBwd _ s = sample_lazy s
 
   stallC conf (head -> (stallAck, stalls))
     = withClockResetEnable clockGen resetGen enableGen

--- a/src/Protocols/Axi4/Stream.hs
+++ b/src/Protocols/Axi4/Stream.hs
@@ -136,8 +136,8 @@ instance (KnownAxi4StreamConfig conf, NFDataX userType, KnownDomain dom) =>
 
   simToSigFwd _ = fromList_lazy
   simToSigBwd _ = fromList_lazy
-  sigToSimFwd _ = sample_lazy
-  sigToSimBwd _ = sample_lazy
+  sigToSimFwd _ s = sample_lazy s
+  sigToSimBwd _ s = sample_lazy s
 
   stallC conf (head -> (stallAck, stalls))
     = withClockResetEnable clockGen resetGen enableGen

--- a/src/Protocols/Df.hs
+++ b/src/Protocols/Df.hs
@@ -153,8 +153,8 @@ instance (C.KnownDomain dom, C.NFDataX a, C.ShowX a, Show a) => Simulate (Df dom
 
   simToSigFwd _ = C.fromList_lazy
   simToSigBwd _ = C.fromList_lazy
-  sigToSimFwd _ = C.sample_lazy
-  sigToSimBwd _ = C.sample_lazy
+  sigToSimFwd _ s = C.sample_lazy s
+  sigToSimBwd _ s = C.sample_lazy s
 
   stallC conf (C.head -> (stallAck, stalls)) = stall conf stallAck stalls
 

--- a/src/Protocols/Internal.hs
+++ b/src/Protocols/Internal.hs
@@ -6,6 +6,7 @@ Internal module to prevent hs-boot files (breaks Haddock)
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- NFDataX and ShowX for Identity and Proxy
 
 module Protocols.Internal where
@@ -726,9 +727,11 @@ type family KeepType (keep :: Bool) (optionalType :: Type) = t | t -> keep optio
   KeepType 'False optionalType = Proxy optionalType
 
 -- TODO this should go into Clash.Prelude (?)
+#if __GLASGOW_HASKELL__ <= 900
 deriving instance (C.ShowX t) => (C.ShowX (Identity t))
-deriving instance (C.ShowX t) => (C.ShowX (Proxy t))
 deriving instance (C.NFDataX t) => (C.NFDataX (Identity t))
+#endif
+deriving instance (C.ShowX t) => (C.ShowX (Proxy t))
 deriving instance (C.NFDataX t) => (C.NFDataX (Proxy t))
 
 -- | We want to define operations on 'KeepType' that work for both possibilities

--- a/src/Protocols/Plugin.hs
+++ b/src/Protocols/Plugin.hs
@@ -3,6 +3,7 @@ A GHC source plugin providing a DSL for writing Circuit components. Credits to
 @circuit-notation@ at <https://github.com/cchalmers/circuit-notation>.
 -}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module Protocols.Plugin where
 
@@ -16,7 +17,11 @@ import           Protocols
 import qualified CircuitNotation as CN
 
 -- ghc
+#if __GLASGOW_HASKELL__ >= 900
+import qualified GHC.Plugins as GHC
+#else
 import qualified GhcPlugins as GHC
+#endif
 
 -- | Type inference helper used by circuit-notation plugin
 type CircuitT a b = (Fwd a, Bwd b) -> (Bwd a, Fwd b)

--- a/src/Protocols/Wishbone/Standard/Hedgehog.hs
+++ b/src/Protocols/Wishbone/Standard/Hedgehog.hs
@@ -293,7 +293,7 @@ driveStandard ExpectOptions {..} reqs =
       . C.fromList_lazy
       . (emptyWishboneM2S :)
       . go eoResetCycles reqs
-      . C.sample_lazy
+      . (\s -> C.sample_lazy s)
       . snd
   where
     transferToSignals ::

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,12 +4,8 @@ packages:
   - .
 
 extra-deps:
-- git: https://github.com/martijnbastiaan/haskell-hedgehog.git
-  commit: 41e87d110d3b2b7b522d29d7c0500672f2640dcc
-  subdirs:
-    - hedgehog
 - git: https://github.com/cchalmers/circuit-notation.git
-  commit: 2574640364eef12222517af059b9e4a7e6b503a7
+  commit: 618e37578e699df235f2e7150108b6401731919b
 - tasty-hedgehog-1.2.0.0
 - clash-prelude-1.6.3
 - clash-prelude-hedgehog-1.6.3


### PR DESCRIPTION
This includes the updated `circuit-notation` plugin and some changes regarding deep subsumption.