### PR TITLE
Expose `CSignal` from `Protocols`

### DIFF
--- a/src/Protocols.hs
+++ b/src/Protocols.hs
@@ -22,6 +22,7 @@ module Protocols
   , fromSignals, toSignals
 
     -- * Protocol types
+  , CSignal
   , Df
 
     -- * Basic circuits


### PR DESCRIPTION
It was never meant to be only exported from `.Internal`.