### PR TITLE
Use `Signal dom ()` in `Bwd (CSignal dom a)` again

### DIFF
--- a/src/Protocols/Internal.hs
+++ b/src/Protocols/Internal.hs
@@ -204,7 +204,7 @@ instance C.KnownNat n => Protocol (C.Vec n a) where
 -- XXX: Type families with Signals on LHS are currently broken on Clash:
 instance Protocol (CSignal dom a) where
   type Fwd (CSignal dom a) = Signal dom a
-  type Bwd (CSignal dom a) = ()
+  type Bwd (CSignal dom a) = Signal dom ()
 
 -- | Left-to-right circuit composition.
 --
@@ -257,7 +257,7 @@ instance (C.KnownNat n, Backpressure a) => Backpressure (C.Vec n a) where
   boolsToBwd _ bs = C.repeat (boolsToBwd (Proxy @a) bs)
 
 instance Backpressure (CSignal dom a) where
-  boolsToBwd _ _ = ()
+  boolsToBwd _ _ = pure ()
 
 -- | Right-to-left circuit composition.
 --

--- a/src/Protocols/Wishbone/Standard.hs
+++ b/src/Protocols/Wishbone/Standard.hs
@@ -89,7 +89,7 @@ crossbarSwitch ::
 crossbarSwitch = Circuit go
  where
   go ((route, bundle -> m2ss0), bundle -> s2ms0) =
-    (((), unbundle s2ms1), unbundle m2ss1)
+    ((pure (), unbundle s2ms1), unbundle m2ss1)
    where
     m2ss1 = scatter @_ @_ @_ @_ @0 (repeat emptyWishboneM2S) <$> route <*> m2ss0
     s2ms1 = gather <$> s2ms0 <*> route


### PR DESCRIPTION
Just a `()` means `dom` gets lost, which makes bundeling and unbundeling impossible. This can make it very awkward to use `CSignal` in practise.