### PR TITLE
Add `forceResetSanity` for all protocols

### DIFF
--- a/src/Protocols/Avalon/MemMap.hs
+++ b/src/Protocols/Avalon/MemMap.hs
@@ -83,6 +83,7 @@ module Protocols.Avalon.MemMap
   , subordinateOutRemoveNonDf
   , subordinateInAddNonDf
   , subordinateInRemoveNonDf
+  , forceResetSanity
 
     -- * Protocols
   , AvalonMmManager(..)
@@ -1272,3 +1273,10 @@ instance (KnownSubordinateConfig config) =>
   IdleCircuit (AvalonMmSubordinate dom fixedWaitTime config) where
     idleFwd _ = pure mmSubordinateInNoData
     idleBwd _ = pure $ boolToMmSubordinateAck False
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  (KnownDomain dom, HiddenReset dom, KnownManagerConfig config) =>
+  Circuit (AvalonMmManager dom config) (AvalonMmManager dom config)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Avalon/Stream.hs
+++ b/src/Protocols/Avalon/Stream.hs
@@ -237,3 +237,10 @@ instance IdleCircuit (AvalonStream dom conf dataType) where
   idleFwd _ = pure Nothing
   idleBwd _ = pure AvalonStreamS2M { _ready = False }
 
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  forall dom conf dataType.
+  ( C.HiddenClockResetEnable dom) =>
+  Circuit (AvalonStream dom conf dataType) (AvalonStream dom conf dataType)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Axi4/ReadAddress.hs
+++ b/src/Protocols/Axi4/ReadAddress.hs
@@ -34,6 +34,9 @@ module Protocols.Axi4.ReadAddress
   , Axi4ReadAddressInfo(..)
   , axi4ReadAddrMsgToReadAddrInfo
   , axi4ReadAddrMsgFromReadAddrInfo
+
+    -- * helpers
+  , forceResetSanity
   ) where
 
 -- base
@@ -368,3 +371,11 @@ axi4ReadAddrMsgFromReadAddrInfo Axi4ReadAddressInfo{..}
 instance IdleCircuit (Axi4ReadAddress dom conf userType) where
   idleFwd _ = pure M2S_NoReadAddress
   idleBwd _ = pure S2M_ReadAddress { _arready = False }
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  forall dom conf userType.
+  ( C.HiddenClockResetEnable dom) =>
+  Circuit (Axi4ReadAddress dom conf userType) (Axi4ReadAddress dom conf userType)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Axi4/ReadData.hs
+++ b/src/Protocols/Axi4/ReadData.hs
@@ -20,6 +20,9 @@ module Protocols.Axi4.ReadData
   , KnownAxi4ReadDataConfig
   , RKeepResponse
   , RIdWidth
+
+    -- * helpers
+  , forceResetSanity
   ) where
 
 -- base
@@ -126,3 +129,11 @@ deriving instance
 instance IdleCircuit (Axi4ReadData dom conf userType dataType) where
   idleFwd _ = C.pure S2M_NoReadData
   idleBwd _ = C.pure $ M2S_ReadData False
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  forall dom conf userType dataType.
+  ( C.HiddenClockResetEnable dom) =>
+  Circuit (Axi4ReadData dom conf userType dataType) (Axi4ReadData dom conf userType dataType)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Axi4/Stream.hs
+++ b/src/Protocols/Axi4/Stream.hs
@@ -177,3 +177,10 @@ instance
 instance IdleCircuit (Axi4Stream dom conf userType) where
   idleFwd Proxy = C.pure Nothing
   idleBwd Proxy = C.pure $ Axi4StreamS2M False
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  (KnownDomain dom, HiddenReset dom) =>
+  Circuit (Axi4Stream dom conf userType) (Axi4Stream dom conf userType)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Axi4/WriteAddress.hs
+++ b/src/Protocols/Axi4/WriteAddress.hs
@@ -34,6 +34,7 @@ module Protocols.Axi4.WriteAddress
   , Axi4WriteAddressInfo(..)
   , axi4WriteAddrMsgToWriteAddrInfo
   , axi4WriteAddrMsgFromWriteAddrInfo
+  , forceResetSanity
   ) where
 
 -- base
@@ -361,3 +362,10 @@ axi4WriteAddrMsgFromWriteAddrInfo _awlen _awburst Axi4WriteAddressInfo{..}
 instance IdleCircuit (Axi4WriteAddress dom conf userType) where
   idleFwd _ = C.pure M2S_NoWriteAddress
   idleBwd _ = C.pure $ S2M_WriteAddress False
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  (C.KnownDomain dom, C.HiddenReset dom) =>
+  Circuit (Axi4WriteAddress dom conf userType) (Axi4WriteAddress dom conf userType)
+forceResetSanity = forceResetSanityGeneric

--- a/src/Protocols/Df.hs
+++ b/src/Protocols/Df.hs
@@ -209,17 +209,9 @@ instance (C.KnownDomain dom, C.NFDataX a, C.ShowX a, Show a) => Drivable (Df dom
 
 -- | Force a /nack/ on the backward channel and /no data/ on the forward
 -- channel if reset is asserted.
-forceResetSanity :: forall dom a. C.HiddenClockResetEnable dom => Circuit (Df dom a) (Df dom a)
-forceResetSanity
-  = Circuit (\(fwd, bwd) -> C.unbundle . fmap f . C.bundle $ (rstLow, fwd, bwd))
- where
-  f (True,  _,   _  ) = (Ack False, NoData)
-  f (False, fwd, bwd) = (bwd, fwd)
-#if MIN_VERSION_clash_prelude(1,8,0)
-  rstLow = C.unsafeToActiveHigh C.hasReset
-#else
-  rstLow = C.unsafeToHighPolarity C.hasReset
-#endif
+forceResetSanity :: forall dom a. C.HiddenClockResetEnable dom =>
+  Circuit (Df dom a) (Df dom a)
+forceResetSanity = forceResetSanityGeneric
 
 -- | Coerce the payload of a Df stream.
 coerce :: (Coerce.Coercible a b) => Circuit (Df dom a) (Df dom b)

--- a/src/Protocols/Wishbone.hs
+++ b/src/Protocols/Wishbone.hs
@@ -245,3 +245,14 @@ emptyWishboneS2M =
 -- | Helper function to determine whether a Slave signals the termination of a cycle.
 hasTerminateFlag :: WishboneS2M dat -> Bool
 hasTerminateFlag s2m = acknowledge s2m || err s2m || retry s2m
+
+-- | Force a /nack/ on the backward channel and /no data/ on the forward
+-- channel if reset is asserted.
+forceResetSanity ::
+  forall dom mode aw a .
+  ( C.HiddenClockResetEnable dom
+  , C.KnownNat aw
+  , C.KnownNat (C.BitSize a)
+  , C.NFDataX a) =>
+  Circuit (Wishbone dom mode aw a) (Wishbone dom mode aw a)
+forceResetSanity = forceResetSanityGeneric


### PR DESCRIPTION
`forceResetSanity` ensures combinatorially that a component does not produce data or acknowledge transactions while in Reset.

Prior to this PR, this functionality was only implemented for `Df`.
This pull requests adds a generic version based on the `IdleCircuit` typeclass to be use internally.