### PR TITLE
Move Documentation check to separate job

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -1,11 +1,50 @@
 #!/bin/bash
+
+me=$(basename "$0")
+# If no arguments are given, print usage
+if [ $# -eq 0 ]; then
+  echo "Usage: . $me --clash <version> --ghc <version>"
+  exit 1
+fi
+
+# Parse command line options
+while (( "$#" )); do
+  case "$1" in
+    --clash)
+      clash_version="$2"
+      shift 2
+      ;;
+    --ghc)
+      ghc="$2"
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+
+# Check if clash_version is set, exit if it's not
+if [[ -z "$clash_version" ]]; then
+  echo "Error: clash_version is not set, use --clash_version" >&2
+  exit 1
+fi
 set -xeou pipefail
 
 # Build dependencies first, so they don't end up in logs
 cabal build \
   --constraint=clash-prelude==$clash_version \
   --enable-documentation \
-  --allow-newer=circuit-notation:ghc \
+  --with-ghc=$ghc \
   clash-protocols
 
 # circuit-notation currently _compiles on 8.10, but isn't usable. The only
@@ -15,7 +54,7 @@ cabal build \
 cabal haddock \
   --constraint=clash-prelude==$clash_version \
   --enable-documentation \
-  --allow-newer=circuit-notation:ghc \
+  --with-ghc=$ghc \
   clash-protocols \
   |& tee haddock_log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,6 @@ jobs:
         run: |
           .ci/test_cabal.sh
 
-      - name: Documentation
-        run: |
-          .ci/build_docs.sh
-
   linting:
     name: Source code linting
     runs-on: ubuntu-latest
@@ -125,3 +121,22 @@ jobs:
       - name: Whitespace
         run: |
           .ci/test_whitespace.sh
+
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: 9.6.4
+          cabal-version: 3.10
+
+      - name: Build
+          # Make sure we use supported versions for Clash and GHC
+        run: |
+          .ci/build_docs.sh --clash 1.8.1 --ghc 9.6.4


### PR DESCRIPTION
Currently all cabal tests can fail due to missing documentation, this is undesirable since we can not distinguish ghc / clash version related problems from missing documentation failures.