### PR TITLE
Export `Reverse`

### DIFF
--- a/src/Protocols.hs
+++ b/src/Protocols.hs
@@ -16,6 +16,7 @@ module Protocols
   , Protocol(Fwd, Bwd)
   , Backpressure(boolsToBwd)
   , Ack(..)
+  , Reverse
 
     -- * Combinators & functions
   , (|>), (<|)


### PR DESCRIPTION
Comes up pretty much instantly when trying to write a `DfConv` instance for protocols where data flows in both directions.