### PR TITLE
Do not verify lengths in `propWithModel`

### DIFF
--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -135,7 +135,8 @@ library
 
   build-depends:
       -- inline-circuit-notation
-      circuit-notation
+    , circuit-notation
+    , clash-prelude-hedgehog
     , data-default
     , deepseq
     , extra

--- a/src/Protocols/Avalon/Stream.hs
+++ b/src/Protocols/Avalon/Stream.hs
@@ -251,9 +251,8 @@ instance
   ) =>
   Test (AvalonStream dom conf dataType)
   where
-  expectToLengths Proxy = pure . P.length
-  expectN Proxy options nExpected sampled =
-    expectN (Proxy @(Df.Df dom _)) options nExpected
+  expectN Proxy options sampled =
+    expectN (Proxy @(Df.Df dom _)) options
       $ Df.maybeToData
       <$> sampled
 

--- a/src/Protocols/Wishbone/Standard/Hedgehog.hs
+++ b/src/Protocols/Wishbone/Standard/Hedgehog.hs
@@ -480,7 +480,7 @@ wishbonePropWithModel eOpts model circuit0 inputGen st = do
     resets = 5
     driver = driveStandard @dom (defExpectOptions{eoResetCycles = resets}) (P.zip input reqStalls)
     circuit1 = validatorCircuit |> circuit0
-    (_, s2m) = observeComposedWishboneCircuit (eoTimeout eOpts) driver circuit1
+    (_, s2m) = observeComposedWishboneCircuit (eoSampleMax eOpts) driver circuit1
 
   matchModel 0 s2m input st === Right ()
  where
@@ -504,17 +504,13 @@ wishbonePropWithModel eOpts model circuit0 inputGen st = do
 
 observeComposedWishboneCircuit ::
   (KnownDomain dom) =>
-  Maybe Int ->
+  Int ->
   Circuit () (Wishbone dom mode addressWidth a) ->
   Circuit (Wishbone dom mode addressWidth a) () ->
   ( [WishboneM2S addressWidth (BitSize a `DivRU` 8) a]
   , [WishboneS2M a]
   )
-observeComposedWishboneCircuit Nothing (Circuit master) (Circuit slave) =
-  let ~((), m2s) = master ((), s2m)
-      ~(s2m, ()) = slave (m2s, ())
-   in (sample_lazy m2s, sample_lazy s2m)
-observeComposedWishboneCircuit (Just n) (Circuit master) (Circuit slave) =
+observeComposedWishboneCircuit n (Circuit master) (Circuit slave) =
   let ~((), m2s) = master ((), s2m)
       ~(s2m, ()) = slave (m2s, ())
    in (sampleN_lazy n m2s, sampleN_lazy n s2m)

--- a/tests/Tests/Protocols/Df.hs
+++ b/tests/Tests/Protocols/Df.hs
@@ -69,7 +69,11 @@ smallInt :: Range Int
 smallInt = Range.linear 0 10
 
 genSmallInt :: Gen Int
-genSmallInt = Gen.integral smallInt
+genSmallInt =
+  Gen.frequency
+    [ (90, Gen.integral smallInt)
+    , (10, Gen.constant (Range.lowerBound 99 smallInt))
+    ]
 
 genSmallPlusInt :: Gen PlusInt
 genSmallPlusInt = coerce <$> genSmallInt

--- a/tests/Tests/Protocols/DfConv.hs
+++ b/tests/Tests/Protocols/DfConv.hs
@@ -257,7 +257,7 @@ tests :: TestTree
 tests =
   -- TODO: Move timeout option to hedgehog for better error messages.
   -- TODO: Does not seem to work for combinatorial loops like @let x = x in x@??
-  localOption (mkTimeout 12_000_000 {- 12 seconds -}) $
+  localOption (mkTimeout 20_000_000 {- 20 seconds -}) $
     localOption
       (HedgehogTestLimit (Just 1000))
       $(testGroupGenerator)


### PR DESCRIPTION
The input length is not always equal to the output length, nor even predictable. Furthermore, some properties might not be interested in the length in the first place.

Fixes #81