### PR TITLE
Add `eoTimeoutMs`

### DIFF
--- a/clash-protocols.cabal
+++ b/clash-protocols.cabal
@@ -143,6 +143,7 @@ library
     , ghc >= 8.7 && < 9.7
     , hashable
     , hedgehog >= 1.0.2
+    , lifted-async
     , mtl
     , pretty-show
     , strict-tuple

--- a/src/Protocols/Hedgehog/Internal.hs
+++ b/src/Protocols/Hedgehog/Internal.hs
@@ -46,6 +46,8 @@ data ExpectOptions = ExpectOptions
   , eoDriveEarly :: Bool
   -- ^ Start driving the circuit with its reset asserted. Circuits should
   -- never acknowledge data while this is happening.
+  , eoTimeoutMs :: Maybe Int
+  -- ^ Terminate the test after /n/ milliseconds.
   }
 
 {- | Resets for 30 cycles, checks for superfluous data for 50 cycles after
@@ -64,6 +66,7 @@ defExpectOptions =
     , eoSampleMax = 256
     , eoResetCycles = 30
     , eoDriveEarly = True
+    , eoTimeoutMs = Nothing
     }
 
 -- | Superclass class to reduce syntactical noise.


### PR DESCRIPTION
Adds the ability to specify a wall-clock timeout to one iteration of `propWithModel`. This can help to hone in on specific inputs causing combinatorial loops.