### PR TITLE
Reexport Protocols.Plugin from clash-protocols

### DIFF
--- a/clash-protocols/clash-protocols.cabal
+++ b/clash-protocols/clash-protocols.cabal
@@ -157,6 +157,9 @@ library
     -- TODO: test / upstream ^
     Test.Tasty.Hedgehog.Extra
 
+  reexported-modules:
+    Protocols.Plugin
+
   autogen-modules:    Paths_clash_protocols
 
   other-modules:


### PR DESCRIPTION
This ensures that the package split introduced in e2f4da3ad5fa9218fd4506c9d433d9adb5c7bfe8 isn't visible to the user.