### PR TITLE
Introduce Protocols.Df.empty

### DIFF
--- a/clash-protocols/src/Protocols/Df.hs
+++ b/clash-protocols/src/Protocols/Df.hs
@@ -22,6 +22,7 @@ module Protocols.Df (
   Data (..),
 
   -- * Operations on Df protocol
+  empty,
   const,
   void,
   pure,
@@ -360,6 +361,10 @@ const b =
         , P.pure (Data b)
         )
     )
+
+-- | Never produce a value.
+empty :: Circuit () (Df dom a)
+empty = Circuit (P.const ((), P.pure NoData))
 
 -- | Drive a constant value composed of /a/.
 pure :: a -> Circuit () (Df dom a)

--- a/clash-protocols/src/Protocols/Df.hs
+++ b/clash-protocols/src/Protocols/Df.hs
@@ -365,7 +365,7 @@ const b =
 pure :: a -> Circuit () (Df dom a)
 pure a = Circuit (P.const ((), P.pure (Data a)))
 
--- | Drive a constant value composed of /a/.
+-- | Never acknowledge values.
 void :: (C.HiddenReset dom) => Circuit (Df dom a) ()
 void =
   Circuit


### PR DESCRIPTION
This combinator is both necessary for completeness and is useful for tying off unused inputs. 