### PR TITLE
Add Vec and unit type instances to IdleCircuit

### DIFF
--- a/clash-protocols/src/Protocols/Idle.hs
+++ b/clash-protocols/src/Protocols/Idle.hs
@@ -9,8 +9,8 @@ module Protocols.Idle (
   idleSink,
 ) where
 
-import Data.Proxy
 import qualified Clash.Prelude as C
+import Data.Proxy
 import Protocols.Cpp (maxTupleSize)
 import Protocols.Internal
 import Protocols.Internal.TH (idleCircuitTupleInstances)

--- a/clash-protocols/src/Protocols/Idle.hs
+++ b/clash-protocols/src/Protocols/Idle.hs
@@ -10,6 +10,7 @@ module Protocols.Idle (
 ) where
 
 import Data.Proxy
+import qualified Clash.Prelude as C
 import Protocols.Cpp (maxTupleSize)
 import Protocols.Internal
 import Protocols.Internal.TH (idleCircuitTupleInstances)
@@ -17,6 +18,14 @@ import Protocols.Internal.TH (idleCircuitTupleInstances)
 instance (IdleCircuit a, IdleCircuit b) => IdleCircuit (a, b) where
   idleFwd _ = (idleFwd $ Proxy @a, idleFwd $ Proxy @b)
   idleBwd _ = (idleBwd $ Proxy @a, idleBwd $ Proxy @b)
+
+instance (IdleCircuit a, C.KnownNat n) => IdleCircuit (C.Vec n a) where
+  idleFwd _ = C.repeat $ idleFwd $ Proxy @a
+  idleBwd _ = C.repeat $ idleBwd $ Proxy @a
+
+instance IdleCircuit () where
+  idleFwd _ = ()
+  idleBwd _ = ()
 
 -- Derive instances for tuples up to maxTupleSize
 idleCircuitTupleInstances 3 maxTupleSize


### PR DESCRIPTION
This enables attaching an idleCircuit to a Vec of protocols and to a Unit type protocol. 
This is useful when using `vecCircuits` to attach multiple slaves to an interconnect.