### PR TITLE
Fix fourmulu check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,8 @@ jobs:
         with:
           version: "0.14.0.0"
           pattern: |
-            src/**/*.hs
-            tests/**/*.hs
-            !src/Protocols/Cpp.hs
+            **/*.hs
+            !clash-protocols-base/src/Protocols/Cpp.hs
 
   linting:
     name: Source code linting

--- a/format.sh
+++ b/format.sh
@@ -25,6 +25,7 @@ fi
 
 exclude_files=(
   "clash-protocols-base/src/Protocols/Cpp.hs"
+  "dist-newstyle"
 )
 
 # Make sure it doesn't matter from where this script is executed
@@ -34,7 +35,7 @@ cd $DIR
 if [ $1 == "diff" ] ; then
   src_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.hs')
 else
-  src_files=$(find clash-protocols-base/Setup.hs clash-protocols/Setup.hs clash-protocols-base/src clash-protocols/src clash-protocols/tests -type f -name "*.hs")
+  src_files=$(find -type f -name "*.hs")
 fi
 
 src_files_str=$(printf "%s\n" "${src_files[@]}" | sed 's| |\\ |g')


### PR DESCRIPTION
Paths were broken after separating `clash-protocols` in 2 packages