### PR TITLE
PacketStream: support zero-byte transfers.

### DIFF
--- a/clash-protocols/clash-protocols.cabal
+++ b/clash-protocols/clash-protocols.cabal
@@ -199,6 +199,7 @@ test-suite unittests
     Tests.Protocols.Wishbone
     Tests.Protocols.PacketStream
     Tests.Protocols.PacketStream.AsyncFifo
+    Tests.Protocols.PacketStream.Base
     Tests.Protocols.PacketStream.Converters
     Tests.Protocols.PacketStream.Delay
     Tests.Protocols.PacketStream.Depacketizers

--- a/clash-protocols/src/Protocols/PacketStream/Delay.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Delay.hs
@@ -18,7 +18,7 @@ import Data.Constraint.Deferrable ((:~:) (Refl))
 import Data.Maybe
 
 type M2SNoMeta dataWidth =
-  (Vec dataWidth (BitVector 8), Maybe (Index dataWidth), Bool)
+  (Vec dataWidth (BitVector 8), Maybe (Index (dataWidth + 1)), Bool)
 
 toPacketstreamM2S :: M2SNoMeta dataWidth -> meta -> PacketStreamM2S dataWidth meta
 toPacketstreamM2S (a, b, c) d = PacketStreamM2S a b d c

--- a/clash-protocols/src/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Depacketizers.hs
@@ -121,7 +121,7 @@ depacketizerT _ Parse{..} (Just PacketStreamM2S{..}, _) = (nextStOut, (PacketStr
   nextParseBuf = fst (shiftInAtN _buf _data)
 
   prematureEnd idx = case sameNat d0 (SNat @(headerBytes `Mod` dataWidth)) of
-    Just Refl -> idx == 0
+    Just Refl -> idx /= maxBound
     _ -> idx < natToNum @(headerBytes `Mod` dataWidth)
 
   -- Upon seeing _last being set, move back to the initial state if the

--- a/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
@@ -286,7 +286,7 @@ dropTailModel SNat packets = L.concatMap go (chunkByPacket packets)
   go packet =
     upConvert
       $ L.init trimmed
-      L.++ [(L.last trimmed){_last = Just 1, _abort = aborted}]
+      L.++ [setNull (L.last trimmed){_last = _last $ L.last bytePkts, _abort = aborted}]
    where
     aborted = L.any _abort packet
     bytePkts = downConvert packet

--- a/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 {- |
 Copyright   : (C) 2024, QBayLogic B.V.
@@ -29,23 +31,24 @@ module Protocols.PacketStream.Hedgehog (
 
   -- * Hedgehog generators
   AbortMode (..),
+  PacketOptions (..),
+  defPacketOptions,
   genValidPacket,
   genPackets,
 ) where
 
-import Prelude
-
 import Clash.Hedgehog.Sized.Vector (genVec)
-import qualified Clash.Prelude as C
+import Clash.Prelude
 import qualified Clash.Sized.Vector as Vec
-
-import Hedgehog (Gen, Range)
-import qualified Hedgehog.Gen as Gen
-
-import Protocols.PacketStream.Base
 
 import qualified Data.List as L
 import Data.Maybe (fromJust, isJust)
+
+import Hedgehog (Gen, Range)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Protocols.PacketStream.Base
 
 -- | Partition a list based on given function.
 chunkBy :: (a -> Bool) -> [a] -> [[a]]
@@ -82,14 +85,14 @@ smearAbort (x : xs) = L.reverse $ L.foldl' go [x] xs
 -- | Partition a list into groups of given size
 chopBy :: Int -> [a] -> [[a]]
 chopBy _ [] = []
-chopBy n xs = as : chopBy n bs where (as, bs) = splitAt n xs
+chopBy n xs = as : chopBy n bs where (as, bs) = L.splitAt n xs
 
 {- |
 Merge a list of `PacketStream` transfers with data width @1@ to
 a single `PacketStream` transfer with data width @dataWidth@.
 -}
 chunkToPacket ::
-  (C.KnownNat dataWidth) =>
+  (KnownNat dataWidth) =>
   [PacketStreamM2S 1 meta] ->
   PacketStreamM2S dataWidth meta
 chunkToPacket xs =
@@ -99,7 +102,7 @@ chunkToPacket xs =
           <$> _last lastTransfer
     , _abort = any _abort xs
     , _meta = _meta lastTransfer
-    , _data = foldr ((C.+>>) . C.head . _data) (C.repeat 0x00) xs
+    , _data = L.foldr ((+>>) . head . _data) (repeat 0x00) xs
     }
  where
   lastTransfer = L.last xs
@@ -110,44 +113,44 @@ a list of `PacketStream` transfers with data width @1@.
 -}
 chopPacket ::
   forall dataWidth meta.
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
   PacketStreamM2S dataWidth meta ->
   [PacketStreamM2S 1 meta]
 chopPacket PacketStreamM2S{..} = packets
  where
   lasts = case _last of
-    Nothing -> repeat Nothing
+    Nothing -> L.repeat Nothing
     Just size ->
       if size == 0
         then [Just 0]
-        else replicate (fromIntegral size - 1) Nothing ++ [Just (1 :: C.Index 2)]
+        else L.replicate (fromIntegral size - 1) Nothing L.++ [Just (1 :: Index 2)]
 
   datas = case _last of
-    Nothing -> C.toList _data
-    Just size -> take (max 1 (fromIntegral size)) $ C.toList _data
+    Nothing -> toList _data
+    Just size -> L.take (max 1 (fromIntegral size)) $ toList _data
 
   packets =
     ( \(size, dat) ->
         PacketStreamM2S (pure dat) size _meta _abort
     )
-      <$> zip lasts datas
+      <$> L.zip lasts datas
 
 -- | Set `_last` of the last transfer in the list to @Just 1@
 fullPackets ::
-  (C.KnownNat dataWidth) =>
+  (KnownNat dataWidth) =>
   [PacketStreamM2S dataWidth meta] ->
   [PacketStreamM2S dataWidth meta]
 fullPackets [] = []
 fullPackets fragments =
-  let lastFragment = (last fragments){_last = Just 1}
-   in init fragments ++ [lastFragment]
+  let lastFragment = (L.last fragments){_last = Just 1}
+   in L.init fragments L.++ [lastFragment]
 
 -- | Drops packets if one of the transfers in the packet has `_abort` set.
 dropAbortedPackets ::
   [PacketStreamM2S dataWidth meta] ->
   [PacketStreamM2S dataWidth meta]
-dropAbortedPackets packets = concat $ filter (not . any _abort) (chunkByPacket packets)
+dropAbortedPackets packets = L.concat $ L.filter (not . any _abort) (chunkByPacket packets)
 
 {- |
 Splits a list of `PacketStream` transfers with data width @1@ into
@@ -155,11 +158,11 @@ a list of `PacketStream` transfers with data width @dataWidth@
 -}
 downConvert ::
   forall dataWidth meta.
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
   [PacketStreamM2S dataWidth meta] ->
   [PacketStreamM2S 1 meta]
-downConvert = concatMap chopPacket
+downConvert = L.concatMap chopPacket
 
 {- |
 Merges a list of `PacketStream` transfers with data width @dataWidth@ into
@@ -167,35 +170,35 @@ a list of `PacketStream` transfers with data width @1@
 -}
 upConvert ::
   forall dataWidth meta.
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
   [PacketStreamM2S 1 meta] ->
   [PacketStreamM2S dataWidth meta]
 upConvert packets =
-  map
+  L.map
     chunkToPacket
-    (chunkByPacket packets >>= chopBy (C.natToNum @dataWidth))
+    (chunkByPacket packets >>= chopBy (natToNum @dataWidth))
 
 -- | Model of the generic `Protocols.PacketStream.depacketizerC`.
 depacketizerModel ::
   forall
-    (dataWidth :: C.Nat)
-    (headerBytes :: C.Nat)
-    (metaIn :: C.Type)
-    (header :: C.Type)
-    (metaOut :: C.Type).
-  (C.KnownNat dataWidth) =>
-  (C.KnownNat headerBytes) =>
-  (1 C.<= dataWidth) =>
-  (1 C.<= headerBytes) =>
-  (C.BitPack header) =>
-  (C.BitSize header ~ headerBytes C.* 8) =>
+    (dataWidth :: Nat)
+    (headerBytes :: Nat)
+    (metaIn :: Type)
+    (header :: Type)
+    (metaOut :: Type).
+  (KnownNat dataWidth) =>
+  (KnownNat headerBytes) =>
+  (1 <= dataWidth) =>
+  (1 <= headerBytes) =>
+  (BitPack header) =>
+  (BitSize header ~ headerBytes * 8) =>
   (header -> metaIn -> metaOut) ->
   [PacketStreamM2S dataWidth metaIn] ->
   [PacketStreamM2S dataWidth metaOut]
 depacketizerModel toMetaOut ps = L.concat dataWidthPackets
  where
-  hdrbytes = C.natToNum @headerBytes
+  hdrbytes = natToNum @headerBytes
 
   parseHdr ::
     ([PacketStreamM2S 1 metaIn], [PacketStreamM2S 1 metaIn]) ->
@@ -208,11 +211,11 @@ depacketizerModel toMetaOut ps = L.concat dataWidthPackets
             (Vec.singleton 0x00)
             (Just 0)
             (error "depacketizerModel: should be replaced")
-            (_abort (last hdrF))
+            (_abort (L.last hdrF))
         ]
       _ -> fwdF
 
-    hdr = C.bitCoerce $ Vec.unsafeFromList @headerBytes $ _data <$> hdrF
+    hdr = bitCoerce $ Vec.unsafeFromList @headerBytes $ _data <$> hdrF
     metaOut = toMetaOut hdr (_meta $ L.head hdrF)
 
   bytePackets :: [[PacketStreamM2S 1 metaIn]]
@@ -220,9 +223,11 @@ depacketizerModel toMetaOut ps = L.concat dataWidthPackets
     L.filter
       ( \fs ->
           let len' = L.length fs
-           in len' > hdrbytes || len' == hdrbytes && _last (last fs) == Just 1
+           in len' > hdrbytes || len' == hdrbytes && _last (L.last fs) == Just 1
       )
-      $ downConvert . smearAbort <$> chunkByPacket ps
+      $ downConvert
+      . smearAbort
+      <$> chunkByPacket ps
 
   parsedPackets :: [[PacketStreamM2S 1 metaOut]]
   parsedPackets = L.map go bytePackets
@@ -235,17 +240,17 @@ depacketizerModel toMetaOut ps = L.concat dataWidthPackets
 -- | Model of the generic `Protocols.PacketStream.depacketizeToDfC`.
 depacketizeToDfModel ::
   forall
-    (dataWidth :: C.Nat)
-    (headerBytes :: C.Nat)
-    (a :: C.Type)
-    (header :: C.Type)
-    (metaIn :: C.Type).
-  (C.KnownNat dataWidth) =>
-  (C.KnownNat headerBytes) =>
-  (1 C.<= dataWidth) =>
-  (1 C.<= headerBytes) =>
-  (C.BitPack header) =>
-  (C.BitSize header ~ headerBytes C.* 8) =>
+    (dataWidth :: Nat)
+    (headerBytes :: Nat)
+    (a :: Type)
+    (header :: Type)
+    (metaIn :: Type).
+  (KnownNat dataWidth) =>
+  (KnownNat headerBytes) =>
+  (1 <= dataWidth) =>
+  (1 <= headerBytes) =>
+  (BitPack header) =>
+  (BitSize header ~ headerBytes * 8) =>
   (header -> metaIn -> a) ->
   [PacketStreamM2S dataWidth metaIn] ->
   [a]
@@ -254,52 +259,53 @@ depacketizeToDfModel toOut ps = L.map parseHdr bytePackets
   parseHdr :: [PacketStreamM2S 1 metaIn] -> a
   parseHdr hdrF =
     toOut
-      (C.bitCoerce $ Vec.unsafeFromList $ _data <$> hdrF)
+      (bitCoerce $ Vec.unsafeFromList $ _data <$> hdrF)
       (_meta $ L.head hdrF)
 
   bytePackets :: [[PacketStreamM2S 1 metaIn]]
   bytePackets =
     L.filter
       ( \pkt ->
-          L.length pkt > C.natToNum @headerBytes
-            || L.length pkt == C.natToNum @headerBytes && _last (last pkt) == Just 1
+          (L.length pkt > natToNum @headerBytes)
+            || (L.length pkt == natToNum @headerBytes && _last (L.last pkt) == Just 1)
       )
       (chunkByPacket $ downConvert (dropAbortedPackets ps))
 
 -- | Model of 'Protocols.PacketStream.dropTailC'.
 dropTailModel ::
   forall dataWidth meta n.
-  (C.KnownNat dataWidth) =>
-  (1 C.<= dataWidth) =>
-  (1 C.<= n) =>
-  C.SNat n ->
+  (KnownNat dataWidth) =>
+  (1 <= dataWidth) =>
+  (1 <= n) =>
+  SNat n ->
   [PacketStreamM2S dataWidth meta] ->
   [PacketStreamM2S dataWidth meta]
-dropTailModel C.SNat packets = L.concatMap go (chunkByPacket packets)
+dropTailModel SNat packets = L.concatMap go (chunkByPacket packets)
  where
   go :: [PacketStreamM2S dataWidth meta] -> [PacketStreamM2S dataWidth meta]
   go packet =
-    upConvert $
-      L.init trimmed L.++ [(L.last trimmed){_last = Just 1, _abort = aborted}]
+    upConvert
+      $ L.init trimmed
+      L.++ [(L.last trimmed){_last = Just 1, _abort = aborted}]
    where
     aborted = L.any _abort packet
     bytePkts = downConvert packet
-    trimmed = L.take (L.length bytePkts - C.natToNum @n) bytePkts
+    trimmed = L.take (L.length bytePkts - natToNum @n) bytePkts
 
 -- | Model of the generic `Protocols.PacketStream.packetizerC`.
 packetizerModel ::
   forall
-    (dataWidth :: C.Nat)
-    (headerBytes :: C.Nat)
-    (metaIn :: C.Type)
-    (header :: C.Type)
-    (metaOut :: C.Type).
-  (C.KnownNat dataWidth) =>
-  (C.KnownNat headerBytes) =>
-  (1 C.<= dataWidth) =>
-  (1 C.<= headerBytes) =>
-  (C.BitPack header) =>
-  (C.BitSize header ~ headerBytes C.* 8) =>
+    (dataWidth :: Nat)
+    (headerBytes :: Nat)
+    (metaIn :: Type)
+    (header :: Type)
+    (metaOut :: Type).
+  (KnownNat dataWidth) =>
+  (KnownNat headerBytes) =>
+  (1 <= dataWidth) =>
+  (1 <= headerBytes) =>
+  (BitPack header) =>
+  (BitSize header ~ headerBytes * 8) =>
   (metaIn -> metaOut) ->
   (metaIn -> header) ->
   [PacketStreamM2S dataWidth metaIn] ->
@@ -311,8 +317,8 @@ packetizerModel toMetaOut toHeader ps = L.concatMap (upConvert . prependHdr) byt
    where
     h = L.head fragments
     metaOut = toMetaOut (_meta h)
-    hdr = L.map go (C.toList $ C.bitCoerce (toHeader (_meta h)))
-    go byte = PacketStreamM2S (C.singleton byte) Nothing metaOut (_abort h)
+    hdr = L.map go (toList $ bitCoerce (toHeader (_meta h)))
+    go byte = PacketStreamM2S (singleton byte) Nothing metaOut (_abort h)
 
   bytePackets :: [[PacketStreamM2S 1 metaIn]]
   bytePackets = downConvert . smearAbort <$> chunkByPacket ps
@@ -320,17 +326,17 @@ packetizerModel toMetaOut toHeader ps = L.concatMap (upConvert . prependHdr) byt
 -- | Model of the generic `Protocols.PacketStream.packetizeFromDfC`.
 packetizeFromDfModel ::
   forall
-    (dataWidth :: C.Nat)
-    (headerBytes :: C.Nat)
-    (a :: C.Type)
-    (header :: C.Type)
-    (metaOut :: C.Type).
-  (C.KnownNat dataWidth) =>
-  (C.KnownNat headerBytes) =>
-  (1 C.<= dataWidth) =>
-  (1 C.<= headerBytes) =>
-  (C.BitPack header) =>
-  (C.BitSize header ~ headerBytes C.* 8) =>
+    (dataWidth :: Nat)
+    (headerBytes :: Nat)
+    (a :: Type)
+    (header :: Type)
+    (metaOut :: Type).
+  (KnownNat dataWidth) =>
+  (KnownNat headerBytes) =>
+  (1 <= dataWidth) =>
+  (1 <= headerBytes) =>
+  (BitPack header) =>
+  (BitSize header ~ headerBytes * 8) =>
   (a -> metaOut) ->
   (a -> header) ->
   [a] ->
@@ -339,126 +345,166 @@ packetizeFromDfModel toMetaOut toHeader = L.concatMap (upConvert . dfToPacket)
  where
   dfToPacket :: a -> [PacketStreamM2S 1 metaOut]
   dfToPacket d =
-    fullPackets $
-      L.map
-        (\byte -> PacketStreamM2S (C.singleton byte) Nothing (toMetaOut d) False)
-        (C.toList $ C.bitCoerce (toHeader d))
+    fullPackets
+      $ L.map
+        (\byte -> PacketStreamM2S (singleton byte) Nothing (toMetaOut d) False)
+        (toList $ bitCoerce (toHeader d))
+
+-- | Abort generation options for packet generation.
+data AbortMode
+  = Abort
+      { amPacketGen :: Gen Bool
+      -- ^ Determines the chance to generate aborted fragments in a packet.
+      , amTransferGen :: Gen Bool
+      -- ^ Determines the frequency of aborted fragments in a packet.
+      }
+  | NoAbort
+
+-- | Various configuration options for packet generation.
+data PacketOptions = PacketOptions
+  { poAllowEmptyPackets :: Bool
+  -- ^ Whether to allow the generation of zero-byte packets.
+  , poAllowTrailingEmpty :: Bool
+  -- ^ Whether to allow the generation of trailing zero-byte transfers.
+  , poAbortMode :: AbortMode
+  -- ^ If set to @NoAbort@, no transfers in the packet will have '_abort' set.
+  -- Else, randomly generate them according to some distribution. See 'AbortMode'.
+  }
 
 {- |
-If set to @NoAbort@, packets will never contain a transfer with _abort set.
-Otherwise, transfers of roughly 50% of the packets will randomly have _abort set.
+Default packet generation options:
+
+- Allow the generation of a zero-byte packet;
+- Allow the generation of a trailing zero-byte transfer;
+- 50% chance to generate aborted transfers. If aborts are generated, 10% of
+  transfers will be aborted.
 -}
-data AbortMode = Abort | NoAbort
+defPacketOptions :: PacketOptions
+defPacketOptions =
+  PacketOptions
+    { poAllowEmptyPackets = True
+    , poAllowTrailingEmpty = True
+    , poAbortMode =
+        Abort
+          { amPacketGen = Gen.enumBounded
+          , amTransferGen =
+              Gen.frequency
+                [ (90, Gen.constant False)
+                , (10, Gen.constant True)
+                ]
+          }
+    }
 
 {- |
-Generate packets with a user-supplied generator.
+Generate packets with a user-supplied generator and a linear range.
 -}
 genPackets ::
-  forall (dataWidth :: C.Nat) (meta :: C.Type).
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
-  -- | The amount of packets to generate.
-  Range Int ->
-  -- | If set to @NoAbort@, always pass @NoAbort@ to the packet generator.
-  --   Else, pass @Abort@ to roughly 50% of the packet generators.
-  AbortMode ->
+  forall (dataWidth :: Nat) (meta :: Type).
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
+  -- | Minimum amount of packets to generate.
+  Int ->
+  -- | Maximum amount of packets to generate.
+  Int ->
   -- | Packet generator.
-  (AbortMode -> Gen [PacketStreamM2S dataWidth meta]) ->
+  Gen [PacketStreamM2S dataWidth meta] ->
   Gen [PacketStreamM2S dataWidth meta]
-genPackets pkts Abort pktGen =
-  concat
-    <$> Gen.list
-      pkts
-      (Gen.choice [pktGen Abort, pktGen NoAbort])
-genPackets pkts NoAbort pktGen =
-  concat
-    <$> Gen.list
-      pkts
-      (pktGen NoAbort)
+genPackets minB maxB pktGen = L.concat <$> Gen.list (Range.linear minB maxB) pktGen
+{-# INLINE genPackets #-}
 
 {- |
 Generate a valid packet, i.e. a packet of which all transfers carry the same
 `_meta` and with all unenabled bytes in `_data` set to 0x00.
 -}
 genValidPacket ::
-  forall (dataWidth :: C.Nat) (meta :: C.Type).
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  forall (dataWidth :: Nat) (meta :: Type).
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
+  -- | Configuration options for packet generation.
+  PacketOptions ->
   -- | Generator for the metadata.
   Gen meta ->
   -- | The amount of transfers with @_last = Nothing@ to generate.
   --   This function will always generate an extra transfer with @_last = Just i@.
   Range Int ->
-  -- | If set to @NoAbort@, no transfers in the packet will have @_abort@ set.
-  --   Else, each transfer has a 10% chance to have @_abort@ set.
-  AbortMode ->
   Gen [PacketStreamM2S dataWidth meta]
-genValidPacket metaGen size abortMode = do
-  meta <- metaGen
-  transfers <- Gen.list size (genTransfer @dataWidth meta abortMode)
-  lastTransfer <- genLastTransfer @dataWidth meta abortMode
-  pure (transfers ++ [lastTransfer])
+genValidPacket opts metaGen size =
+  let
+    abortGen = case opts.poAbortMode of
+      NoAbort -> Gen.constant False
+      Abort pktGen transferGen -> do
+        allowAborts <- pktGen
+        (if allowAborts then transferGen else Gen.constant False)
+   in
+    do
+      meta <- metaGen
+      transfers <- Gen.list size (genTransfer meta abortGen)
+      lastTransfer <-
+        genLastTransfer
+          meta
+          ( (null transfers && opts.poAllowEmptyPackets)
+              || (not (null transfers) && opts.poAllowTrailingEmpty)
+          )
+          abortGen
+      pure (transfers L.++ [lastTransfer])
 
 -- | Generate a single transfer which is not yet the end of a packet.
 genTransfer ::
-  forall (dataWidth :: C.Nat) (meta :: C.Type).
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  forall (dataWidth :: Nat) (meta :: Type).
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
   -- | We need to use the same metadata
   --   for every transfer in a packet to satisfy the protocol
   --   invariant that metadata is constant for an entire packet.
   meta ->
-  -- | If set to @NoAbort@, hardcode @_abort@ to @False@. Else,
-  --   there is a 10% chance for it to be set.
-  AbortMode ->
+  -- | Whether to set '_abort'.
+  Gen Bool ->
   Gen (PacketStreamM2S dataWidth meta)
-genTransfer meta abortMode =
+genTransfer meta abortGen =
   PacketStreamM2S
     <$> genVec Gen.enumBounded
     <*> Gen.constant Nothing
     <*> Gen.constant meta
-    <*> case abortMode of
-      Abort ->
-        Gen.frequency
-          [ (90, Gen.constant False)
-          , (10, Gen.constant True)
-          ]
-      NoAbort -> Gen.constant False
+    <*> abortGen
 
 {- |
 Generate the last transfer of a packet, i.e. a transfer with @_last@ set as @Just@.
 All bytes which are not enabled are set to 0x00.
 -}
 genLastTransfer ::
-  forall (dataWidth :: C.Nat) (meta :: C.Type).
-  (1 C.<= dataWidth) =>
-  (C.KnownNat dataWidth) =>
+  forall (dataWidth :: Nat) (meta :: Type).
+  (1 <= dataWidth) =>
+  (KnownNat dataWidth) =>
   -- | We need to use the same metadata
   --   for every transfer in a packet to satisfy the protocol
   --   invariant that metadata is constant for an entire packet.
   meta ->
-  -- | If set to @NoAbort@, hardcode @_abort@ to @False@. Else,
-  --   randomly generate it.
-  AbortMode ->
+  -- | Whether we are allowed to generate a 0-byte transfer.
+  Bool ->
+  -- | Whether to set '_abort'.
+  Gen Bool ->
   Gen (PacketStreamM2S dataWidth meta)
-genLastTransfer meta abortMode =
+genLastTransfer meta allowEmpty abortGen =
   setNull
     <$> ( PacketStreamM2S
             <$> genVec Gen.enumBounded
-            <*> (Just <$> Gen.enumBounded)
+            <*> (Just <$> Gen.enum (if allowEmpty then 0 else 1) maxBound)
             <*> Gen.constant meta
-            <*> case abortMode of
-              Abort -> Gen.enumBounded
-              NoAbort -> Gen.constant False
+            <*> abortGen
         )
- where
-  setNull transfer =
-    let i = fromJust (_last transfer)
-     in transfer
-          { _data =
-              fromJust
-                ( Vec.fromList $
-                    take (fromIntegral i) (C.toList (_data transfer))
-                      ++ replicate ((C.natToNum @dataWidth) - fromIntegral i) 0x00
-                )
-          }
+
+setNull ::
+  forall (dataWidth :: Nat) (meta :: Type).
+  (KnownNat dataWidth) =>
+  PacketStreamM2S dataWidth meta ->
+  PacketStreamM2S dataWidth meta
+setNull transfer =
+  let i = fromJust (_last transfer)
+   in transfer
+        { _data =
+            fromJust
+              ( Vec.fromList
+                  $ L.take (fromIntegral i) (toList (_data transfer))
+                  L.++ L.replicate ((natToNum @dataWidth) - fromIntegral i) 0x00
+              )
+        }

--- a/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -428,9 +427,9 @@ genValidPacket ::
   --   This function will always generate an extra transfer with @_last = Just i@.
   Range Int ->
   Gen [PacketStreamM2S dataWidth meta]
-genValidPacket opts metaGen size =
+genValidPacket PacketOptions{..} metaGen size =
   let
-    abortGen = case opts.poAbortMode of
+    abortGen = case poAbortMode of
       NoAbort -> Gen.constant False
       Abort pktGen transferGen -> do
         allowAborts <- pktGen
@@ -442,8 +441,8 @@ genValidPacket opts metaGen size =
       lastTransfer <-
         genLastTransfer
           meta
-          ( (null transfers && opts.poAllowEmptyPackets)
-              || (not (null transfers) && opts.poAllowTrailingEmpty)
+          ( (null transfers && poAllowEmptyPackets)
+              || (not (null transfers) && poAllowTrailingEmpty)
           )
           abortGen
       pure (transfers L.++ [lastTransfer])

--- a/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Hedgehog.hs
@@ -203,11 +203,17 @@ depacketizerModel toMetaOut ps = L.concat dataWidthPackets
   parseHdr (hdrF, fwdF) = fmap (\f -> f{_meta = metaOut}) fwdF'
    where
     fwdF' = case fwdF of
-      [] -> [PacketStreamM2S (Vec.singleton 0x00) (Just 0) (C.errorX "u") (_abort (last hdrF))]
+      [] ->
+        [ PacketStreamM2S
+            (Vec.singleton 0x00)
+            (Just 0)
+            (error "depacketizerModel: should be replaced")
+            (_abort (last hdrF))
+        ]
       _ -> fwdF
 
     hdr = C.bitCoerce $ Vec.unsafeFromList @headerBytes $ _data <$> hdrF
-    metaOut = toMetaOut hdr (_meta $ L.head fwdF)
+    metaOut = toMetaOut hdr (_meta $ L.head hdrF)
 
   bytePackets :: [[PacketStreamM2S 1 metaIn]]
   bytePackets =

--- a/clash-protocols/src/Protocols/PacketStream/PacketFifo.hs
+++ b/clash-protocols/src/Protocols/PacketStream/PacketFifo.hs
@@ -19,7 +19,7 @@ import Data.Maybe
 import Data.Maybe.Extra
 
 type PacketStreamContent (dataWidth :: Nat) (meta :: Type) =
-  (Vec dataWidth (BitVector 8), Maybe (Index dataWidth))
+  (Vec dataWidth (BitVector 8), Maybe (Index (dataWidth + 1)))
 
 toPacketStreamContent ::
   PacketStreamM2S dataWidth meta -> PacketStreamContent dataWidth meta

--- a/clash-protocols/tests/Tests/Protocols/PacketStream.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream.hs
@@ -3,6 +3,7 @@ module Tests.Protocols.PacketStream (tests) where
 import Test.Tasty
 
 import qualified Tests.Protocols.PacketStream.AsyncFifo
+import qualified Tests.Protocols.PacketStream.Base
 import qualified Tests.Protocols.PacketStream.Converters
 import qualified Tests.Protocols.PacketStream.Delay
 import qualified Tests.Protocols.PacketStream.Depacketizers
@@ -15,6 +16,7 @@ tests =
   testGroup
     "PacketStream"
     [ Tests.Protocols.PacketStream.AsyncFifo.tests
+    , Tests.Protocols.PacketStream.Base.tests
     , Tests.Protocols.PacketStream.Converters.tests
     , Tests.Protocols.PacketStream.Delay.tests
     , Tests.Protocols.PacketStream.Depacketizers.tests

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/AsyncFifo.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/AsyncFifo.hs
@@ -71,8 +71,7 @@ generateAsyncFifoIdProp ::
 generateAsyncFifoIdProp wClk wRst wEn rClk rRst rEn =
   idWithModel
     defExpectOptions
-    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 1 30))
-    )
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 30)))
     id
     (asyncFifoC @wDom @rDom @4 @1 @Int d4 wClk wRst wEn rClk rRst rEn)
 

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Tests.Protocols.PacketStream.Base (
+  tests,
+) where
+
+import Clash.Prelude
+
+import qualified Data.List as L
+import Data.List.Extra (unsnoc)
+
+import Hedgehog (Property)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Test.Tasty (TestTree, localOption, mkTimeout)
+import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
+import Test.Tasty.Hedgehog.Extra (testProperty)
+import Test.Tasty.TH (testGroupGenerator)
+
+import Protocols.Hedgehog
+import Protocols.PacketStream.Base
+import Protocols.PacketStream.Hedgehog
+
+prop_strip_trailing_empty :: Property
+prop_strip_trailing_empty =
+  idWithModelSingleDomain
+    @System
+    defExpectOptions
+    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 0 10))
+    )
+    (exposeClockResetEnable model')
+    (exposeClockResetEnable (stripTrailingEmptyC @1 @Char))
+ where
+  model' packets = L.concatMap model (chunkByPacket packets)
+
+  model :: [PacketStreamM2S 1 Char] -> [PacketStreamM2S 1 Char]
+  model packet = case unsnoc packet of
+    Nothing -> []
+    Just (xs, l) -> case unsnoc xs of
+      -- Preserve packets that consist of a single zero-byte transfer.
+      Nothing -> [l]
+      Just (ys, l2) -> if _last l == Just 0 then ys L.++ [l2{_last = Just maxBound}] else packet
+
+tests :: TestTree
+tests =
+  localOption (mkTimeout 20_000_000 {- 20 seconds -}) $
+    localOption
+      (HedgehogTestLimit (Just 500))
+      $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Tests.Protocols.PacketStream.Base (
   tests,
@@ -40,11 +41,14 @@ prop_strip_trailing_empty =
     Just (xs, l) -> case unsnoc xs of
       -- Preserve packets that consist of a single zero-byte transfer.
       Nothing -> [l]
-      Just (ys, l2) -> if _last l == Just 0 then ys L.++ [l2{_last = Just maxBound}] else packet
+      Just (ys, l2) ->
+        if _last l == Just 0
+          then ys L.++ [l2{_last = Just maxBound, _abort = _abort l2 || _abort l}]
+          else packet
 
 tests :: TestTree
 tests =
-  localOption (mkTimeout 20_000_000 {- 20 seconds -}) $
-    localOption
+  localOption (mkTimeout 20_000_000 {- 20 seconds -})
+    $ localOption
       (HedgehogTestLimit (Just 500))
       $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
@@ -28,8 +28,7 @@ prop_strip_trailing_empty =
   idWithModelSingleDomain
     @System
     defExpectOptions
-    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 0 10))
-    )
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
     (exposeClockResetEnable model')
     (exposeClockResetEnable (stripTrailingEmptyC @1 @Char))
  where

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
@@ -32,8 +32,7 @@ generateUpConverterProperty ::
 generateUpConverterProperty SNat SNat =
   idWithModelSingleDomain
     defExpectOptions
-    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 1 20))
-    )
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 20)))
     (exposeClockResetEnable (upConvert . downConvert))
     (exposeClockResetEnable @System (upConverterC @dwIn @dwOut @Int))
 
@@ -50,7 +49,7 @@ generateDownConverterProperty ::
 generateDownConverterProperty SNat SNat =
   idWithModelSingleDomain
     defExpectOptions{eoSampleMax = 1000}
-    (genPackets (Range.linear 1 8) Abort (genValidPacket Gen.enumBounded (Range.linear 1 10)))
+    (genPackets 1 8 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
     (exposeClockResetEnable (upConvert . downConvert))
     (exposeClockResetEnable @System (downConverterC @dwIn @dwOut @Int))
 

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
@@ -35,6 +35,26 @@ generateUpConverterProperty SNat SNat =
     (exposeClockResetEnable (upConvert . downConvert))
     (exposeClockResetEnable @System (upConverterC @dwIn @dwOut @Int))
 
+generateDownConverterProperty ::
+  forall (dwIn :: Nat) (dwOut :: Nat) (n :: Nat).
+  (1 <= dwIn) =>
+  (1 <= dwOut) =>
+  (1 <= n) =>
+  (KnownNat n) =>
+  (dwIn ~ n * dwOut) =>
+  SNat dwIn ->
+  SNat dwOut ->
+  Property
+generateDownConverterProperty SNat SNat =
+  idWithModelSingleDomain
+    defExpectOptions{eoSampleMax = 1000}
+    (genPackets (Range.linear 1 8) Abort (genValidPacket Gen.enumBounded (Range.linear 1 10)))
+    (exposeClockResetEnable (upConvert . downConvert))
+    (exposeClockResetEnable @System (downConverterC @dwIn @dwOut @Int))
+
+prop_downConverter3to9 :: Property
+prop_downConverter3to9 = generateUpConverterProperty d3 d9
+
 prop_upConverter4to8 :: Property
 prop_upConverter4to8 = generateUpConverterProperty d4 d8
 
@@ -53,22 +73,8 @@ prop_upConverter1to2 = generateUpConverterProperty d1 d2
 prop_upConverter1to1 :: Property
 prop_upConverter1to1 = generateUpConverterProperty d1 d1
 
-generateDownConverterProperty ::
-  forall (dwIn :: Nat) (dwOut :: Nat) (n :: Nat).
-  (1 <= dwIn) =>
-  (1 <= dwOut) =>
-  (1 <= n) =>
-  (KnownNat n) =>
-  (dwIn ~ n * dwOut) =>
-  SNat dwIn ->
-  SNat dwOut ->
-  Property
-generateDownConverterProperty SNat SNat =
-  idWithModelSingleDomain
-    defExpectOptions{eoSampleMax = 1000}
-    (genPackets (Range.linear 1 8) Abort (genValidPacket Gen.enumBounded (Range.linear 1 10)))
-    (exposeClockResetEnable (upConvert . downConvert))
-    (exposeClockResetEnable @System (downConverterC @dwIn @dwOut @Int))
+prop_downConverter9to3 :: Property
+prop_downConverter9to3 = generateDownConverterProperty d9 d3
 
 prop_downConverter8to4 :: Property
 prop_downConverter8to4 = generateDownConverterProperty d8 d4

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Converters.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE NumericUnderscores #-}
 
-module Tests.Protocols.PacketStream.Converters where
+module Tests.Protocols.PacketStream.Converters (
+  tests,
+) where
 
 import Clash.Prelude
 
@@ -52,8 +54,8 @@ generateDownConverterProperty SNat SNat =
     (exposeClockResetEnable (upConvert . downConvert))
     (exposeClockResetEnable @System (downConverterC @dwIn @dwOut @Int))
 
-prop_downConverter3to9 :: Property
-prop_downConverter3to9 = generateUpConverterProperty d3 d9
+prop_upConverter3to9 :: Property
+prop_upConverter3to9 = generateUpConverterProperty d3 d9
 
 prop_upConverter4to8 :: Property
 prop_upConverter4to8 = generateUpConverterProperty d4 d8

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Delay.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Delay.hs
@@ -24,8 +24,7 @@ prop_delaystream_id =
   idWithModelSingleDomain
     @System
     defExpectOptions
-    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 4 20))
-    )
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 4 20)))
     (exposeClockResetEnable id)
     (exposeClockResetEnable (delayStreamC @2 @Int d4))
 

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
@@ -39,7 +39,7 @@ depacketizerPropertyGenerator SNat SNat =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    (genPackets (Range.linear 1 4) Abort (genValidPacket (pure ()) (Range.linear 1 30)))
+    (genPackets (Range.linear 1 4) Abort (genValidPacket (pure ()) (Range.linear 0 30)))
     (exposeClockResetEnable (depacketizerModel const))
     (exposeClockResetEnable ckt)
  where
@@ -67,7 +67,7 @@ depacketizeToDfPropertyGenerator SNat SNat =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    (genPackets (Range.linear 1 10) Abort (genValidPacket (pure ()) (Range.linear 1 20)))
+    (genPackets (Range.linear 1 10) Abort (genValidPacket (pure ()) (Range.linear 0 20)))
     (exposeClockResetEnable (depacketizeToDfModel const))
     (exposeClockResetEnable ckt)
  where
@@ -164,5 +164,5 @@ tests :: TestTree
 tests =
   localOption (mkTimeout 20_000_000 {- 20 seconds -}) $
     localOption
-      (HedgehogTestLimit (Just 100))
+      (HedgehogTestLimit (Just 500))
       $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
@@ -88,7 +88,7 @@ dropTailTest ::
 dropTailTest SNat n =
   idWithModelSingleDomain
     @System
-    defExpectOptions -- (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
+    defExpectOptions
     ( genPackets
         1
         4

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
@@ -39,7 +39,7 @@ depacketizerPropertyGenerator SNat SNat =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    (genPackets (Range.linear 1 4) Abort (genValidPacket (pure ()) (Range.linear 0 30)))
+    (genPackets 1 4 (genValidPacket defPacketOptions (pure ()) (Range.linear 0 30)))
     (exposeClockResetEnable (depacketizerModel const))
     (exposeClockResetEnable ckt)
  where
@@ -67,7 +67,7 @@ depacketizeToDfPropertyGenerator SNat SNat =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    (genPackets (Range.linear 1 10) Abort (genValidPacket (pure ()) (Range.linear 0 20)))
+    (genPackets 1 10 (genValidPacket defPacketOptions (pure ()) (Range.linear 0 20)))
     (exposeClockResetEnable (depacketizeToDfModel const))
     (exposeClockResetEnable ckt)
  where
@@ -88,11 +88,12 @@ dropTailTest ::
 dropTailTest SNat n =
   idWithModelSingleDomain
     @System
-    defExpectOptions
+    defExpectOptions -- (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
     ( genPackets
-        (Range.linear 1 4)
-        Abort
+        1
+        4
         ( genValidPacket
+            defPacketOptions
             (Gen.int8 Range.linearBounded)
             (Range.linear (natToNum @(n `DivRU` dataWidth)) 20)
         )

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Depacketizers.hs
@@ -134,17 +134,17 @@ prop_const_depacketize_to_df_d5_d4 = depacketizeToDfPropertyGenerator d5 d4
 
 -- | dataWidth < n && dataWidth % n ~ 0
 prop_droptail_4_bytes_d1 :: Property
-prop_droptail_4_bytes_d1 = dropTailTest d4 d1
+prop_droptail_4_bytes_d1 = dropTailTest d1 d4
 
 prop_droptail_7_bytes_d1 :: Property
-prop_droptail_7_bytes_d1 = dropTailTest d7 d1
+prop_droptail_7_bytes_d1 = dropTailTest d1 d7
 
 -- | dataWidth < n && dataWidth % n > 0
 prop_droptail_4_bytes_d3 :: Property
-prop_droptail_4_bytes_d3 = dropTailTest d4 d3
+prop_droptail_4_bytes_d3 = dropTailTest d3 d4
 
 prop_droptail_7_bytes_d4 :: Property
-prop_droptail_7_bytes_d4 = dropTailTest d7 d4
+prop_droptail_7_bytes_d4 = dropTailTest d4 d7
 
 -- | dataWidth ~ n
 prop_droptail_4_bytes_d4 :: Property
@@ -155,14 +155,14 @@ prop_droptail_7_bytes_d7 = dropTailTest d7 d7
 
 -- | dataWidth > n
 prop_droptail_4_bytes_d7 :: Property
-prop_droptail_4_bytes_d7 = dropTailTest d4 d7
+prop_droptail_4_bytes_d7 = dropTailTest d7 d4
 
 prop_droptail_7_bytes_d12 :: Property
-prop_droptail_7_bytes_d12 = dropTailTest d7 d12
+prop_droptail_7_bytes_d12 = dropTailTest d12 d7
 
 tests :: TestTree
 tests =
   localOption (mkTimeout 20_000_000 {- 20 seconds -}) $
     localOption
-      (HedgehogTestLimit (Just 500))
+      (HedgehogTestLimit (Just 100))
       $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/PacketFifo.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/PacketFifo.hs
@@ -31,8 +31,7 @@ prop_packetFifo_id =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    ( genPackets (Range.linear 1 30) Abort (genValidPacket Gen.enumBounded (Range.linear 1 10))
-    )
+    (genPackets 1 30 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
     (exposeClockResetEnable dropAbortedPackets)
     (exposeClockResetEnable ckt)
  where
@@ -47,8 +46,7 @@ prop_packetFifo_small_buffer_id =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 1000, eoStopAfterEmpty = 1000}
-    ( genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 1 30))
-    )
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 30)))
     (exposeClockResetEnable dropAbortedPackets)
     (exposeClockResetEnable ckt)
  where
@@ -70,9 +68,10 @@ prop_packetFifo_no_gaps = property $ do
           enableGen
       gen =
         genPackets
-          (Range.linear 1 10)
-          NoAbort
-          (genValidPacket Gen.enumBounded (Range.linear 1 10))
+          1
+          10
+          ( genValidPacket defPacketOptions{poAbortMode = NoAbort} Gen.enumBounded (Range.linear 0 10)
+          )
 
   packets :: [PacketStreamM2S 4 Int16] <- forAll gen
 
@@ -93,8 +92,7 @@ prop_overFlowDrop_packetFifo_id =
   idWithModelSingleDomain
     @System
     defExpectOptions{eoSampleMax = 2000, eoStopAfterEmpty = 1000}
-    ( genPackets (Range.linear 1 30) Abort (genValidPacket Gen.enumBounded (Range.linear 1 10))
-    )
+    (genPackets 1 30 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 10)))
     (exposeClockResetEnable dropAbortedPackets)
     (exposeClockResetEnable ckt)
  where
@@ -124,8 +122,13 @@ prop_overFlowDrop_packetFifo_drop =
    where
     packetChunk = chunkByPacket packets
 
-  genSmall = genValidPacket Gen.enumBounded (Range.linear 1 5) NoAbort
-  genBig = genValidPacket Gen.enumBounded (Range.linear 33 33) NoAbort
+  genSmall =
+    genValidPacket defPacketOptions{poAbortMode = NoAbort} Gen.enumBounded (Range.linear 1 5)
+  genBig =
+    genValidPacket
+      defPacketOptions{poAbortMode = NoAbort}
+      Gen.enumBounded
+      (Range.linear 33 33)
 
 -- | test for id using a small metabuffer to ensure backpressure using the metabuffer is tested
 prop_packetFifo_small_metaBuffer :: Property
@@ -133,7 +136,7 @@ prop_packetFifo_small_metaBuffer =
   idWithModelSingleDomain
     @System
     defExpectOptions
-    (genPackets (Range.linear 1 30) Abort (genValidPacket Gen.enumBounded (Range.linear 1 4)))
+    (genPackets 1 30 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 4)))
     (exposeClockResetEnable dropAbortedPackets)
     (exposeClockResetEnable ckt)
  where

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
@@ -24,8 +24,9 @@ import Protocols.PacketStream (packetizeFromDfC, packetizerC)
 import Protocols.PacketStream.Base
 import Protocols.PacketStream.Hedgehog
 
-{- | Test the packetizer with varying datawidth and number of bytes in the header,
-  with metaOut = ().
+{- |
+Test the packetizer with varying datawidth and number of bytes in the header,
+with metaOut = ().
 -}
 packetizerPropertyGenerator ::
   forall
@@ -56,24 +57,9 @@ packetizerPropertyGenerator SNat SNat =
       (PacketStream System dataWidth ())
   ckt = packetizerC (const ()) id
 
--- | headerBytes % dataWidth ~ 0
-prop_const_packetizer_d1_d14 :: Property
-prop_const_packetizer_d1_d14 = packetizerPropertyGenerator d1 d14
-
--- | dataWidth < headerBytes
-prop_const_packetizer_d3_d11 :: Property
-prop_const_packetizer_d3_d11 = packetizerPropertyGenerator d3 d11
-
--- | dataWidth ~ header byte size
-prop_const_packetizer_d7_d7 :: Property
-prop_const_packetizer_d7_d7 = packetizerPropertyGenerator d7 d7
-
--- | dataWidth > header byte size
-prop_const_packetizer_d5_d4 :: Property
-prop_const_packetizer_d5_d4 = packetizerPropertyGenerator d5 d4
-
-{- | Test packetizeFromDf with varying datawidth and number of bytes in the header
-  , with metaOut = ().
+{- |
+Test packetizeFromDf with varying datawidth and number of bytes in the header,
+with metaOut = ().
 -}
 packetizeFromDfPropertyGenerator ::
   forall
@@ -97,6 +83,22 @@ packetizeFromDfPropertyGenerator SNat SNat =
     (HiddenClockResetEnable System) =>
     Circuit (Df.Df System (Vec headerBytes (BitVector 8))) (PacketStream System dataWidth ())
   ckt = packetizeFromDfC (const ()) id
+
+-- | headerBytes % dataWidth ~ 0
+prop_const_packetizer_d1_d14 :: Property
+prop_const_packetizer_d1_d14 = packetizerPropertyGenerator d1 d14
+
+-- | dataWidth < headerBytes
+prop_const_packetizer_d3_d11 :: Property
+prop_const_packetizer_d3_d11 = packetizerPropertyGenerator d3 d11
+
+-- | dataWidth ~ header byte size
+prop_const_packetizer_d7_d7 :: Property
+prop_const_packetizer_d7_d7 = packetizerPropertyGenerator d7 d7
+
+-- | dataWidth > header byte size
+prop_const_packetizer_d5_d4 :: Property
+prop_const_packetizer_d5_d4 = packetizerPropertyGenerator d5 d4
 
 -- | headerBytes % dataWidth ~ 0
 prop_const_packetizeFromDf_d1_d14 :: Property

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
@@ -42,9 +42,9 @@ packetizerPropertyGenerator SNat SNat =
     @System
     defExpectOptions
     ( genPackets
-        (Range.linear 1 10)
-        Abort
-        (genValidPacket (genVec Gen.enumBounded) (Range.linear 0 10))
+        1
+        10
+        (genValidPacket defPacketOptions (genVec Gen.enumBounded) (Range.linear 0 10))
     )
     (exposeClockResetEnable model)
     (exposeClockResetEnable ckt)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Packetizers.hs
@@ -44,7 +44,7 @@ packetizerPropertyGenerator SNat SNat =
     ( genPackets
         (Range.linear 1 10)
         Abort
-        (genValidPacket (genVec Gen.enumBounded) (Range.linear 1 10))
+        (genValidPacket (genVec Gen.enumBounded) (Range.linear 0 10))
     )
     (exposeClockResetEnable model)
     (exposeClockResetEnable ckt)

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Routing.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Routing.hs
@@ -66,7 +66,7 @@ makePropPacketArbiter _ _ mode =
   genSources = mapM setMeta (indicesI @p)
   setMeta j = do
     pkts <-
-      genPackets @n (Range.linear 1 10) Abort (genValidPacket (pure ()) (Range.linear 1 10))
+      genPackets @n 1 10 (genValidPacket defPacketOptions (pure ()) (Range.linear 0 10))
     pure $ L.map (\pkt -> pkt{_meta = j}) pkts
 
   partitionPackets packets =
@@ -117,7 +117,7 @@ makePropPacketDispatcher ::
 makePropPacketDispatcher _ fs =
   idWithModelSingleDomain @System
     defExpectOptions{eoSampleMax = 2000, eoStopAfterEmpty = 1000}
-    (genPackets (Range.linear 1 10) Abort (genValidPacket Gen.enumBounded (Range.linear 1 6)))
+    (genPackets 1 10 (genValidPacket defPacketOptions Gen.enumBounded (Range.linear 0 6)))
     (exposeClockResetEnable (model 0))
     (exposeClockResetEnable (packetDispatcherC fs))
  where


### PR DESCRIPTION
Adds support for zero-byte transfers in the `PacketStream` protocol. The type of `_last` is updated from `Index dataWidth` to `Index (dataWidth + 1)` and now means "the number of valid bytes in the transfer" instead of "the index of the last valid byte in the transfer".

Note that components are free to refuse zero-byte packets or packets with trailing zero-byte transfers. This should be well-documented. Thus, also added ways to not generate such packets in the test framework. The newly added 'stripTrailingEmptyC' merges trailing zero-byte transfers with the previous one.