### PR TITLE
Use more quotations in TH module

### DIFF
--- a/clash-protocols/src/Protocols/Internal.hs
+++ b/clash-protocols/src/Protocols/Internal.hs
@@ -265,6 +265,7 @@ instance (Drivable a, Drivable b) => Drivable (a, b) where
       )
 
 drivableTupleInstances 3 maxTupleSize
+
 instance (CE.KnownNat n, Simulate a) => Simulate (C.Vec n a) where
   type SimulateFwdType (C.Vec n a) = C.Vec n (SimulateFwdType a)
   type SimulateBwdType (C.Vec n a) = C.Vec n (SimulateBwdType a)


### PR DESCRIPTION
We can use more quotations and less "bare" TH constructions.

This was intended as a change to #117, but it was already merged.