### PR TITLE
Support Clash current master

### DIFF
--- a/clash-protocols/src/Protocols/Df.hs
+++ b/clash-protocols/src/Protocols/Df.hs
@@ -902,6 +902,28 @@ registerBwd =
     iDatX1 = C.regEn (C.errorX "registerBwd") oAck iDatX0
     oDat = toData <$> valid <*> (C.mux oAck iDatX0 iDatX1)
 
+-- Fourmolu only allows CPP conditions on complete top-level definitions. This
+-- function is not exported.
+blockRamUNoClear ::
+  forall n dom a addr.
+  ( HasCallStack
+  , C.HiddenClockResetEnable dom
+  , C.NFDataX a
+  , Enum addr
+  , C.NFDataX addr
+  , 1 <= n
+  ) =>
+  C.SNat n ->
+  Signal dom addr ->
+  Signal dom (Maybe (addr, a)) ->
+  Signal dom a
+#if MIN_VERSION_clash_prelude(1,9,0)
+blockRamUNoClear = C.blockRamU C.NoClearOnReset
+#else
+blockRamUNoClear n =
+  C.blockRamU C.NoClearOnReset n (C.errorX "No reset function")
+#endif
+
 {- | A fifo buffer with user-provided depth. Uses blockram to store data. Can
 handle simultaneous write and read (full throughput rate).
 -}
@@ -923,7 +945,7 @@ fifo fifoDepth = Circuit $ C.hideReset circuitFunction
     -- initialize bram
     brRead =
       C.readNew
-        (C.blockRamU C.NoClearOnReset fifoDepth (C.errorX "No reset function"))
+        (blockRamUNoClear fifoDepth)
         brReadAddr
         brWrite
     -- run the state machine (a mealy machine)


### PR DESCRIPTION
The type of `blockRamU` has changed since Clash 1.8.

The `clash-cores` package explicitly targets both Clash 1.8 and Clash master. Since we want to add `clash-protocols` as a dependency to `clash-cores`, we need `clash-protocols` to support Clash master.
