### PR TITLE
Fix CI for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If a push triggers a GitHub Action, it does not have the property `github.head_ref`, leading to an immediate failure. We generally solve this by falling back to `github.run_id`.

Note that if it does fall back to run_id becasue head_ref was unset, the `cancel-in-progress` will not work since the run ID is unique for the run, so there will never be multiple runs in a single concurrency group.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

Additionally, it is now possible to manually trigger a CI run. If the last run for the main branch was so long ago that its caches expired, and you open multiple PR's before merging one, each PR will have to rebuild all dependencies because they only can get their caches from the main branch or that specific PR. If you know this is what is going to happen, you could trigger a CI run on main to have fresh caches, and only open the PR's after that.
