### PR TITLE
Fix use of deprecated OPTIONS pragma

### DIFF
--- a/clash-protocols/tests/Tests/Protocols/Plugin.hs
+++ b/clash-protocols/tests/Tests/Protocols/Plugin.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE BlockArguments #-}
-
-{-# OPTIONS -fplugin=Protocols.Plugin #-}
+-- This /must/ be enabled in order for the plugin to do its work. You might
+-- want to add this to 'ghc-options' in your cabal file.
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
 
 -- For debugging purposes:
--- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
+-- {-# OPTIONS_GHC -fplugin-opt=Protocols.Plugin:debug #-}
 
-{- | This /must/ be enabled in order for the plugin to do its work. You might
-want to add this to 'ghc-options' in your cabal file.
--}
 module Tests.Protocols.Plugin where
 
 import qualified Clash.Prelude as C


### PR DESCRIPTION
Per [the documentation](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/pragmas.html#options-ghc-pragma):

> Previous versions of GHC accepted `OPTIONS` rather than `OPTIONS_GHC`, but that is now deprecated.

Additionally, the Haddock module description seemed to refer to the `-fplugin` option rather than actually describing the module, so the comment is moved and made a regular comment instead of a Haddock block. For consistency with the rest of the code base, line comments are used instead of block comments.
