### PR TITLE
AXI: Add `BitPack` instance to all channel signals

### DIFF
--- a/clash-protocols/src/Protocols/Axi4/Common.hs
+++ b/clash-protocols/src/Protocols/Axi4/Common.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE UndecidableInstances #-}
--- NFDataX and ShowX for T3 and T4
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- |
 Types and utilities shared between AXI4, AXI4-Lite, and AXI3.
@@ -20,40 +16,7 @@ import GHC.TypeNats (Nat)
 import Clash.Prelude (type (-), type (^))
 import qualified Clash.Prelude as C
 
--- strict-tuple
-import Data.Tuple.Strict (T3, T4)
-
 import Protocols.Internal
-
-deriving instance
-  ( C.NFDataX a
-  , C.NFDataX b
-  , C.NFDataX c
-  ) =>
-  C.NFDataX (T3 a b c)
-
-deriving instance
-  ( C.NFDataX a
-  , C.NFDataX b
-  , C.NFDataX c
-  , C.NFDataX d
-  ) =>
-  C.NFDataX (T4 a b c d)
-
-deriving instance
-  ( C.ShowX a
-  , C.ShowX b
-  , C.ShowX c
-  ) =>
-  C.ShowX (T3 a b c)
-
-deriving instance
-  ( C.ShowX a
-  , C.ShowX b
-  , C.ShowX c
-  , C.ShowX d
-  ) =>
-  C.ShowX (T4 a b c d)
 
 -- | Enables or disables 'BurstMode'
 type BurstType (keep :: Bool) = KeepType keep BurstMode
@@ -70,9 +33,8 @@ type LastType (keep :: Bool) = KeepType keep Bool
 -- | Enables or disables 'AtomicAccess'
 type LockType (keep :: Bool) = KeepType keep AtomicAccess
 
--- | Enables or disables 'Privileged', 'Secure', and 'InstructionOrData'
-type PermissionsType (keep :: Bool) =
-  KeepType keep (T3 Privileged Secure InstructionOrData)
+-- | Enables or disables 'Permissions'
+type PermissionsType (keep :: Bool) = KeepType keep Permissions
 
 -- | Enables or disables 'Qos'
 type QosType (keep :: Bool) = KeepType keep Qos
@@ -222,7 +184,7 @@ data OtherAllocate = OtherNoLookupCache | OtherLookupCache
   deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
 
 -- | See Table A4-3 AWCACHE bit allocations
-type Cache = T4 Bufferable Modifiable OtherAllocate Allocate
+type Cache = (Bufferable, Modifiable, OtherAllocate, Allocate)
 
 -- | Status of the write transaction.
 data Resp
@@ -279,3 +241,6 @@ data InstructionOrData
   = Data
   | Instruction
   deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+
+-- | Enables or disables 'Privileged', 'Secure', and 'InstructionOrData'
+type Permissions = (Privileged, Secure, InstructionOrData)

--- a/clash-protocols/src/Protocols/Axi4/Common.hs
+++ b/clash-protocols/src/Protocols/Axi4/Common.hs
@@ -24,8 +24,11 @@ type BurstType (keep :: Bool) = KeepType keep BurstMode
 -- | Enables or disables burst length
 type BurstLengthType (keep :: Bool) = KeepType keep (C.Index (2 ^ 8))
 
--- | Enables or disables 'Cache'
-type CacheType (keep :: Bool) = KeepType keep Cache
+-- | Enables or disables the 'ArCache' for Write Address operations
+type AwCacheType (keep :: Bool) = KeepType keep AwCache
+
+-- | Enables or disables the 'ArCache' for Read Address operations
+type ArCacheType (keep :: Bool) = KeepType keep ArCache
 
 -- | Enables or disables a boolean indicating whether a transaction is done
 type LastType (keep :: Bool) = KeepType keep Bool
@@ -183,8 +186,15 @@ allocated in the cache for performance reasons.
 data OtherAllocate = OtherNoLookupCache | OtherLookupCache
   deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
--- | See Table A4-3 AWCACHE bit allocations
-type Cache = (Bufferable, Modifiable, OtherAllocate, Allocate)
+{- | Memory attributes. Note that the 'Allocate' and 'OtherAllocate' bits are
+in different posistions for read and write requests.
+-}
+type AwCache = (Bufferable, Modifiable, OtherAllocate, Allocate)
+
+{- | Memory attributes. Note that the 'Allocate' and 'OtherAllocate' bits are
+in different posistions for read and write requests.
+-}
+type ArCache = (Bufferable, Modifiable, Allocate, OtherAllocate)
 
 -- | Status of the write transaction.
 data Resp

--- a/clash-protocols/src/Protocols/Axi4/Common.hs
+++ b/clash-protocols/src/Protocols/Axi4/Common.hs
@@ -139,7 +139,7 @@ data BurstMode
     --
     -- This burst type is used for cache line accesses.
     BmWrap
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | The maximum number of bytes to transfer in each data transfer, or beat,
 in a burst.
@@ -153,7 +153,7 @@ data BurstSize
   | Bs32
   | Bs64
   | Bs128
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 -- | Convert burst size to a numeric value
 burstSizeToNum :: (Num a) => BurstSize -> a
@@ -169,19 +169,19 @@ burstSizeToNum = \case
 
 -- | Whether a transaction is bufferable
 data Bufferable = NonBufferable | Bufferable
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | When set to "LookupCache", it is recommended that this transaction is
 allocated in the cache for performance reasons.
 -}
 data Allocate = NoLookupCache | LookupCache
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | When set to "OtherLookupCache", it is recommended that this transaction is
 allocated in the cache for performance reasons.
 -}
 data OtherAllocate = OtherNoLookupCache | OtherLookupCache
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 -- | See Table A4-3 AWCACHE bit allocations
 type Cache = (Bufferable, Modifiable, OtherAllocate, Allocate)
@@ -200,19 +200,19 @@ data Resp
   | -- | Decode error. Generated, typically by an interconnect component, to
     -- indicate that there is no slave at the transaction address.
     RDecodeError
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 -- | Whether a resource is accessed with exclusive access or not
 data AtomicAccess
   = NonExclusiveAccess
   | ExclusiveAccess
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 -- | Whether transaction can be modified
 data Modifiable
   = Modifiable
   | NonModifiable
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | An AXI master might support Secure and Non-secure operating states, and
 extend this concept of security to memory access.
@@ -220,7 +220,7 @@ extend this concept of security to memory access.
 data Secure
   = Secure
   | NonSecure
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | An AXI master might support more than one level of operating privilege,
 and extend this concept of privilege to memory access.
@@ -228,7 +228,7 @@ and extend this concept of privilege to memory access.
 data Privileged
   = NotPrivileged
   | Privileged
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 {- | Whether the transaction is an instruction access or a data access. The AXI
 protocol defines this indication as a hint. It is not accurate in all cases,
@@ -240,7 +240,7 @@ instruction access.
 data InstructionOrData
   = Data
   | Instruction
-  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq)
+  deriving (Show, C.ShowX, Generic, C.NFDataX, NFData, Eq, C.BitPack)
 
 -- | Enables or disables 'Privileged', 'Secure', and 'InstructionOrData'
 type Permissions = (Privileged, Secure, InstructionOrData)

--- a/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
@@ -175,7 +175,7 @@ data
       -- ^ Burst type*
       , _arlock :: !(LockType (ARKeepLock conf))
       -- ^ Lock type*
-      , _arcache :: !(CacheType (ARKeepCache conf))
+      , _arcache :: !(ArCacheType (ARKeepCache conf))
       -- ^ Cache type* (has been renamed to modifiable in AXI spec)
       , _arprot :: !(PermissionsType (ARKeepPermissions conf))
       -- ^ Protection type
@@ -212,7 +212,7 @@ type KnownAxi4ReadAddressConfig conf =
   , C.ShowX (SizeType (ARKeepSize conf))
   , C.ShowX (BurstType (ARKeepBurst conf))
   , C.ShowX (LockType (ARKeepLock conf))
-  , C.ShowX (CacheType (ARKeepCache conf))
+  , C.ShowX (ArCacheType (ARKeepCache conf))
   , C.ShowX (PermissionsType (ARKeepPermissions conf))
   , C.ShowX (QosType (ARKeepQos conf))
   , Show (RegionType (ARKeepRegion conf))
@@ -220,7 +220,7 @@ type KnownAxi4ReadAddressConfig conf =
   , Show (SizeType (ARKeepSize conf))
   , Show (BurstType (ARKeepBurst conf))
   , Show (LockType (ARKeepLock conf))
-  , Show (CacheType (ARKeepCache conf))
+  , Show (ArCacheType (ARKeepCache conf))
   , Show (PermissionsType (ARKeepPermissions conf))
   , Show (QosType (ARKeepQos conf))
   , C.NFDataX (RegionType (ARKeepRegion conf))
@@ -228,7 +228,7 @@ type KnownAxi4ReadAddressConfig conf =
   , C.NFDataX (SizeType (ARKeepSize conf))
   , C.NFDataX (BurstType (ARKeepBurst conf))
   , C.NFDataX (LockType (ARKeepLock conf))
-  , C.NFDataX (CacheType (ARKeepCache conf))
+  , C.NFDataX (ArCacheType (ARKeepCache conf))
   , C.NFDataX (PermissionsType (ARKeepPermissions conf))
   , C.NFDataX (QosType (ARKeepQos conf))
   , NFData (RegionType (ARKeepRegion conf))
@@ -236,7 +236,7 @@ type KnownAxi4ReadAddressConfig conf =
   , NFData (SizeType (ARKeepSize conf))
   , NFData (BurstType (ARKeepBurst conf))
   , NFData (LockType (ARKeepLock conf))
-  , NFData (CacheType (ARKeepCache conf))
+  , NFData (ArCacheType (ARKeepCache conf))
   , NFData (PermissionsType (ARKeepPermissions conf))
   , NFData (QosType (ARKeepQos conf))
   , Eq (RegionType (ARKeepRegion conf))
@@ -244,7 +244,7 @@ type KnownAxi4ReadAddressConfig conf =
   , Eq (SizeType (ARKeepSize conf))
   , Eq (BurstType (ARKeepBurst conf))
   , Eq (LockType (ARKeepLock conf))
-  , Eq (CacheType (ARKeepCache conf))
+  , Eq (ArCacheType (ARKeepCache conf))
   , Eq (PermissionsType (ARKeepPermissions conf))
   , Eq (QosType (ARKeepQos conf))
   )
@@ -283,7 +283,7 @@ data Axi4ReadAddressInfo (conf :: Axi4ReadAddressConfig) (userType :: Type) = Ax
   -- ^ Burst type
   , _arilock :: !(LockType (ARKeepLock conf))
   -- ^ Lock type
-  , _aricache :: !(CacheType (ARKeepCache conf))
+  , _aricache :: !(ArCacheType (ARKeepCache conf))
   -- ^ Cache type
   , _ariprot :: !(PermissionsType (ARKeepPermissions conf))
   -- ^ Protection type

--- a/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
@@ -173,7 +173,7 @@ data
       -- ^ Burst type*
       , _awlock :: !(LockType (AWKeepLock conf))
       -- ^ Lock type*
-      , _awcache :: !(CacheType (AWKeepCache conf))
+      , _awcache :: !(AwCacheType (AWKeepCache conf))
       -- ^ Cache type*
       , _awprot :: !(PermissionsType (AWKeepPermissions conf))
       -- ^ Protection type
@@ -209,7 +209,7 @@ type KnownAxi4WriteAddressConfig conf =
   , C.ShowX (SizeType (AWKeepSize conf))
   , C.ShowX (BurstType (AWKeepBurst conf))
   , C.ShowX (LockType (AWKeepLock conf))
-  , C.ShowX (CacheType (AWKeepCache conf))
+  , C.ShowX (AwCacheType (AWKeepCache conf))
   , C.ShowX (PermissionsType (AWKeepPermissions conf))
   , C.ShowX (QosType (AWKeepQos conf))
   , Show (RegionType (AWKeepRegion conf))
@@ -217,7 +217,7 @@ type KnownAxi4WriteAddressConfig conf =
   , Show (SizeType (AWKeepSize conf))
   , Show (BurstType (AWKeepBurst conf))
   , Show (LockType (AWKeepLock conf))
-  , Show (CacheType (AWKeepCache conf))
+  , Show (AwCacheType (AWKeepCache conf))
   , Show (PermissionsType (AWKeepPermissions conf))
   , Show (QosType (AWKeepQos conf))
   , C.NFDataX (RegionType (AWKeepRegion conf))
@@ -225,7 +225,7 @@ type KnownAxi4WriteAddressConfig conf =
   , C.NFDataX (SizeType (AWKeepSize conf))
   , C.NFDataX (BurstType (AWKeepBurst conf))
   , C.NFDataX (LockType (AWKeepLock conf))
-  , C.NFDataX (CacheType (AWKeepCache conf))
+  , C.NFDataX (AwCacheType (AWKeepCache conf))
   , C.NFDataX (PermissionsType (AWKeepPermissions conf))
   , C.NFDataX (QosType (AWKeepQos conf))
   , NFData (RegionType (AWKeepRegion conf))
@@ -233,7 +233,7 @@ type KnownAxi4WriteAddressConfig conf =
   , NFData (SizeType (AWKeepSize conf))
   , NFData (BurstType (AWKeepBurst conf))
   , NFData (LockType (AWKeepLock conf))
-  , NFData (CacheType (AWKeepCache conf))
+  , NFData (AwCacheType (AWKeepCache conf))
   , NFData (PermissionsType (AWKeepPermissions conf))
   , NFData (QosType (AWKeepQos conf))
   , Eq (RegionType (AWKeepRegion conf))
@@ -241,7 +241,7 @@ type KnownAxi4WriteAddressConfig conf =
   , Eq (SizeType (AWKeepSize conf))
   , Eq (BurstType (AWKeepBurst conf))
   , Eq (LockType (AWKeepLock conf))
-  , Eq (CacheType (AWKeepCache conf))
+  , Eq (AwCacheType (AWKeepCache conf))
   , Eq (PermissionsType (AWKeepPermissions conf))
   , Eq (QosType (AWKeepQos conf))
   )
@@ -276,7 +276,7 @@ data Axi4WriteAddressInfo (conf :: Axi4WriteAddressConfig) (userType :: Type) = 
   -- ^ Burst size
   , _awilock :: !(LockType (AWKeepLock conf))
   -- ^ Lock type
-  , _awicache :: !(CacheType (AWKeepCache conf))
+  , _awicache :: !(AwCacheType (AWKeepCache conf))
   -- ^ Cache type
   , _awiprot :: !(PermissionsType (AWKeepPermissions conf))
   -- ^ Protection type

--- a/clash-protocols/tests/Tests/Protocols/Axi4.hs
+++ b/clash-protocols/tests/Tests/Protocols/Axi4.hs
@@ -244,8 +244,8 @@ prop_axi4_convert_read_id =
               <$> ( (,,,)
                       <$> (pure NonBufferable C.<|> pure Bufferable)
                       <*> (pure NonModifiable C.<|> pure Modifiable)
-                      <*> (pure OtherNoLookupCache C.<|> pure OtherLookupCache)
                       <*> (pure NoLookupCache C.<|> pure LookupCache)
+                      <*> (pure OtherNoLookupCache C.<|> pure OtherLookupCache)
                   )
           )
       <*> ( toKeepType
@@ -309,8 +309,8 @@ prop_axi4_convert_read_id_rev =
           toKeepType
             ( NonBufferable
             , NonModifiable
-            , OtherNoLookupCache
             , NoLookupCache
+            , OtherNoLookupCache
             )
       , _ariprot =
           toKeepType

--- a/clash-protocols/tests/Tests/Protocols/Axi4.hs
+++ b/clash-protocols/tests/Tests/Protocols/Axi4.hs
@@ -18,9 +18,6 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
--- strict-tuple
-import Data.Tuple.Strict (T3 (..), T4 (..))
-
 -- tasty
 import Test.Tasty
 import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
@@ -111,7 +108,7 @@ prop_axi4_convert_write_id =
           )
       <*> (toKeepType <$> (pure NonExclusiveAccess C.<|> pure ExclusiveAccess))
       <*> ( toKeepType
-              <$> ( T4
+              <$> ( (,,,)
                       <$> (pure NonBufferable C.<|> pure Bufferable)
                       <*> (pure NonModifiable C.<|> pure Modifiable)
                       <*> (pure OtherNoLookupCache C.<|> pure OtherLookupCache)
@@ -119,7 +116,7 @@ prop_axi4_convert_write_id =
                   )
           )
       <*> ( toKeepType
-              <$> ( T3
+              <$> ( (,,)
                       <$> (pure Privileged C.<|> pure NotPrivileged)
                       <*> (pure Secure C.<|> pure NonSecure)
                       <*> (pure Instruction C.<|> pure Data)
@@ -178,18 +175,16 @@ prop_axi4_convert_write_id_rev =
         , _awilock = toKeepType NonExclusiveAccess
         , _awicache =
             toKeepType
-              ( T4
-                  NonBufferable
-                  NonModifiable
-                  OtherNoLookupCache
-                  NoLookupCache
+              ( NonBufferable
+              , NonModifiable
+              , OtherNoLookupCache
+              , NoLookupCache
               )
         , _awiprot =
             toKeepType
-              ( T3
-                  Privileged
-                  Secure
-                  Instruction
+              ( Privileged
+              , Secure
+              , Instruction
               )
         , _awiqos = toKeepType 0
         , _awiuser = 0
@@ -246,7 +241,7 @@ prop_axi4_convert_read_id =
       <*> (toKeepType <$> (pure BmFixed C.<|> pure BmIncr C.<|> pure BmWrap))
       <*> (toKeepType <$> (pure NonExclusiveAccess C.<|> pure ExclusiveAccess))
       <*> ( toKeepType
-              <$> ( T4
+              <$> ( (,,,)
                       <$> (pure NonBufferable C.<|> pure Bufferable)
                       <*> (pure NonModifiable C.<|> pure Modifiable)
                       <*> (pure OtherNoLookupCache C.<|> pure OtherLookupCache)
@@ -254,7 +249,7 @@ prop_axi4_convert_read_id =
                   )
           )
       <*> ( toKeepType
-              <$> ( T3
+              <$> ( (,,)
                       <$> (pure Privileged C.<|> pure NotPrivileged)
                       <*> (pure Secure C.<|> pure NonSecure)
                       <*> (pure Instruction C.<|> pure Data)
@@ -312,18 +307,16 @@ prop_axi4_convert_read_id_rev =
       , _arilock = toKeepType NonExclusiveAccess
       , _aricache =
           toKeepType
-            ( T4
-                NonBufferable
-                NonModifiable
-                OtherNoLookupCache
-                NoLookupCache
+            ( NonBufferable
+            , NonModifiable
+            , OtherNoLookupCache
+            , NoLookupCache
             )
       , _ariprot =
           toKeepType
-            ( T3
-                Privileged
-                Secure
-                Instruction
+            ( Privileged
+            , Secure
+            , Instruction
             )
       , _ariqos = toKeepType 0
       , _ariuser = 0


### PR DESCRIPTION
To be honest, I'm not sure why these datatypes did not already have a `BitPack` instance.