### PR TITLE
Remove strict evaluation from AXI channel fields

### DIFF
--- a/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
@@ -158,27 +158,27 @@ data
     (userType :: Type)
   = M2S_NoReadAddress
   | M2S_ReadAddress
-      { _arid :: !(C.BitVector (ARIdWidth conf))
+      { _arid :: C.BitVector (ARIdWidth conf)
       -- ^ Read address id*
-      , _araddr :: !(C.BitVector (ARAddrWidth conf))
+      , _araddr :: C.BitVector (ARAddrWidth conf)
       -- ^ Read address
-      , _arregion :: !(RegionType (ARKeepRegion conf))
+      , _arregion :: RegionType (ARKeepRegion conf)
       -- ^ Read region*
-      , _arlen :: !(BurstLengthType (ARKeepBurstLength conf))
+      , _arlen :: BurstLengthType (ARKeepBurstLength conf)
       -- ^ Burst length*
-      , _arsize :: !(SizeType (ARKeepSize conf))
+      , _arsize :: SizeType (ARKeepSize conf)
       -- ^ Burst size*
-      , _arburst :: !(BurstType (ARKeepBurst conf))
+      , _arburst :: BurstType (ARKeepBurst conf)
       -- ^ Burst type*
-      , _arlock :: !(LockType (ARKeepLock conf))
+      , _arlock :: LockType (ARKeepLock conf)
       -- ^ Lock type*
-      , _arcache :: !(ArCacheType (ARKeepCache conf))
+      , _arcache :: ArCacheType (ARKeepCache conf)
       -- ^ Cache type* (has been renamed to modifiable in AXI spec)
-      , _arprot :: !(PermissionsType (ARKeepPermissions conf))
+      , _arprot :: PermissionsType (ARKeepPermissions conf)
       -- ^ Protection type
-      , _arqos :: !(QosType (ARKeepQos conf))
+      , _arqos :: QosType (ARKeepQos conf)
       -- ^ QoS value
-      , _aruser :: !userType
+      , _aruser :: userType
       -- ^ User data
       }
   deriving (Generic)
@@ -269,27 +269,27 @@ one-to-one with the fields of 'M2S_ReadAddress' except for '_arlen',
 '_arsize', and '_arburst'.
 -}
 data Axi4ReadAddressInfo (conf :: Axi4ReadAddressConfig) (userType :: Type) = Axi4ReadAddressInfo
-  { _ariid :: !(C.BitVector (ARIdWidth conf))
+  { _ariid :: C.BitVector (ARIdWidth conf)
   -- ^ Id
-  , _ariaddr :: !(C.BitVector (ARAddrWidth conf))
+  , _ariaddr :: C.BitVector (ARAddrWidth conf)
   -- ^ Address
-  , _ariregion :: !(RegionType (ARKeepRegion conf))
+  , _ariregion :: RegionType (ARKeepRegion conf)
   -- ^ Region
-  , _arilen :: !(BurstLengthType (ARKeepBurstLength conf))
+  , _arilen :: BurstLengthType (ARKeepBurstLength conf)
   -- ^ Burst length
-  , _arisize :: !(SizeType (ARKeepSize conf))
+  , _arisize :: SizeType (ARKeepSize conf)
   -- ^ Burst size
-  , _ariburst :: !(BurstType (ARKeepBurst conf))
+  , _ariburst :: BurstType (ARKeepBurst conf)
   -- ^ Burst type
-  , _arilock :: !(LockType (ARKeepLock conf))
+  , _arilock :: LockType (ARKeepLock conf)
   -- ^ Lock type
-  , _aricache :: !(ArCacheType (ARKeepCache conf))
+  , _aricache :: ArCacheType (ARKeepCache conf)
   -- ^ Cache type
-  , _ariprot :: !(PermissionsType (ARKeepPermissions conf))
+  , _ariprot :: PermissionsType (ARKeepPermissions conf)
   -- ^ Protection type
-  , _ariqos :: !(QosType (ARKeepQos conf))
+  , _ariqos :: QosType (ARKeepQos conf)
   -- ^ QoS value
-  , _ariuser :: !userType
+  , _ariuser :: userType
   -- ^ User data
   }
   deriving (Generic)

--- a/clash-protocols/src/Protocols/Axi4/ReadData.hs
+++ b/clash-protocols/src/Protocols/Axi4/ReadData.hs
@@ -92,15 +92,15 @@ data
     (dataType :: Type)
   = S2M_NoReadData
   | S2M_ReadData
-      { _rid :: !(C.BitVector (RIdWidth conf))
+      { _rid :: C.BitVector (RIdWidth conf)
       -- ^ Read address id*
-      , _rdata :: !dataType
+      , _rdata :: dataType
       -- ^ Read data
-      , _rresp :: !(ResponseType (RKeepResponse conf))
+      , _rresp :: ResponseType (RKeepResponse conf)
       -- ^ Read response
-      , _rlast :: !Bool
+      , _rlast :: Bool
       -- ^ Read last
-      , _ruser :: !userType
+      , _ruser :: userType
       -- ^ User data
       }
   deriving (Generic)

--- a/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
@@ -155,27 +155,27 @@ data
     (userType :: Type)
   = M2S_NoWriteAddress
   | M2S_WriteAddress
-      { _awid :: !(C.BitVector (AWIdWidth conf))
+      { _awid :: C.BitVector (AWIdWidth conf)
       -- ^ Write address id*
-      , _awaddr :: !(C.BitVector (AWAddrWidth conf))
+      , _awaddr :: C.BitVector (AWAddrWidth conf)
       -- ^ Write address
-      , _awregion :: !(RegionType (AWKeepRegion conf))
+      , _awregion :: RegionType (AWKeepRegion conf)
       -- ^ Write region*
-      , _awlen :: !(BurstLengthType (AWKeepBurstLength conf))
+      , _awlen :: BurstLengthType (AWKeepBurstLength conf)
       -- ^ Burst length*
-      , _awsize :: !(SizeType (AWKeepSize conf))
+      , _awsize :: SizeType (AWKeepSize conf)
       -- ^ Burst size*
-      , _awburst :: !(BurstType (AWKeepBurst conf))
+      , _awburst :: BurstType (AWKeepBurst conf)
       -- ^ Burst type*
-      , _awlock :: !(LockType (AWKeepLock conf))
+      , _awlock :: LockType (AWKeepLock conf)
       -- ^ Lock type*
-      , _awcache :: !(AwCacheType (AWKeepCache conf))
+      , _awcache :: AwCacheType (AWKeepCache conf)
       -- ^ Cache type*
-      , _awprot :: !(PermissionsType (AWKeepPermissions conf))
+      , _awprot :: PermissionsType (AWKeepPermissions conf)
       -- ^ Protection type
-      , _awqos :: !(QosType (AWKeepQos conf))
+      , _awqos :: QosType (AWKeepQos conf)
       -- ^ QoS value
-      , _awuser :: !userType
+      , _awuser :: userType
       -- ^ User data
       }
   deriving (Generic)
@@ -270,23 +270,23 @@ one-to-one with the fields of 'M2S_WriteAddress' except for '_awlen',
 '_awsize', and '_awburst'.
 -}
 data Axi4WriteAddressInfo (conf :: Axi4WriteAddressConfig) (userType :: Type) = Axi4WriteAddressInfo
-  { _awiid :: !(C.BitVector (AWIdWidth conf))
+  { _awiid :: C.BitVector (AWIdWidth conf)
   -- ^ Id
-  , _awiaddr :: !(C.BitVector (AWAddrWidth conf))
+  , _awiaddr :: C.BitVector (AWAddrWidth conf)
   -- ^ Address
-  , _awiregion :: !(RegionType (AWKeepRegion conf))
+  , _awiregion :: RegionType (AWKeepRegion conf)
   -- ^ Region
-  , _awisize :: !(SizeType (AWKeepSize conf))
+  , _awisize :: SizeType (AWKeepSize conf)
   -- ^ Burst size
-  , _awilock :: !(LockType (AWKeepLock conf))
+  , _awilock :: LockType (AWKeepLock conf)
   -- ^ Lock type
-  , _awicache :: !(AwCacheType (AWKeepCache conf))
+  , _awicache :: AwCacheType (AWKeepCache conf)
   -- ^ Cache type
-  , _awiprot :: !(PermissionsType (AWKeepPermissions conf))
+  , _awiprot :: PermissionsType (AWKeepPermissions conf)
   -- ^ Protection type
-  , _awiqos :: !(QosType (AWKeepQos conf))
+  , _awiqos :: QosType (AWKeepQos conf)
   -- ^ QoS value
-  , _awiuser :: !userType
+  , _awiuser :: userType
   -- ^ User data
   }
   deriving (Generic)

--- a/clash-protocols/src/Protocols/Axi4/WriteData.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteData.hs
@@ -90,11 +90,11 @@ data
     (userType :: Type)
   = M2S_NoWriteData
   | M2S_WriteData
-      { _wdata :: !(StrictStrobeType (WNBytes conf) (WKeepStrobe conf))
+      { _wdata :: StrictStrobeType (WNBytes conf) (WKeepStrobe conf)
       -- ^ Write data
-      , _wlast :: !Bool
+      , _wlast :: Bool
       -- ^ Write last
-      , _wuser :: !userType
+      , _wuser :: userType
       -- ^ User data
       }
   deriving (Generic)

--- a/clash-protocols/src/Protocols/Axi4/WriteResponse.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteResponse.hs
@@ -75,11 +75,11 @@ data
     (userType :: Type)
   = S2M_NoWriteResponse
   | S2M_WriteResponse
-      { _bid :: !(C.BitVector (BIdWidth conf))
+      { _bid :: C.BitVector (BIdWidth conf)
       -- ^ Response ID
-      , _bresp :: !(ResponseType (BKeepResponse conf))
+      , _bresp :: ResponseType (BKeepResponse conf)
       -- ^ Write response
-      , _buser :: !userType
+      , _buser :: userType
       -- ^ User data
       }
   deriving (Generic)


### PR DESCRIPTION
These fields were made strict out of a fear of space leaks according to Martijn. But this was never really well defended, so we switch to what the rest of the Haskell ecosystem does: laziness.