### PR TITLE
Make `prod2C` lazy in its arguments + Add `prod3C` and `prod4C`

### DIFF
--- a/clash-protocols/src/Protocols/Internal.hs
+++ b/clash-protocols/src/Protocols/Internal.hs
@@ -182,6 +182,38 @@ prod2C ab cd = circuit $ \(a, c) -> do
   d <- cd -< c
   idC -< (b, d)
 
+{- | Combine three separate circuits into one. If you are looking to combine
+multiple streams into a single stream, checkout 'Protocols.Df.fanin'.
+-}
+prod3C ::
+  forall a c b d e f.
+  Circuit a b ->
+  Circuit c d ->
+  Circuit e f ->
+  Circuit (a, c, e) (b, d, f)
+prod3C ab cd ef = circuit $ \(a, c, e) -> do
+  b <- ab -< a
+  d <- cd -< c
+  f <- ef -< e
+  idC -< (b, d, f)
+
+{- | Combine four separate circuits into one. If you are looking to combine
+multiple streams into a single stream, checkout 'Protocols.Df.fanin'.
+-}
+prod4C ::
+  forall a c b d e f g h.
+  Circuit a b ->
+  Circuit c d ->
+  Circuit e f ->
+  Circuit g h ->
+  Circuit (a, c, e, g) (b, d, f, h)
+prod4C ab cd ef gh = circuit $ \(a, c, e, g) -> do
+  b <- ab -< a
+  d <- cd -< c
+  f <- ef -< e
+  h <- gh -< g
+  idC -< (b, d, f, h)
+
 --------------------------------- SIMULATION -----------------------------------
 
 instance Simulate () where

--- a/clash-protocols/src/Protocols/Internal.hs
+++ b/clash-protocols/src/Protocols/Internal.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
 -- TODO: Hide internal documentation
 -- {-# OPTIONS_HADDOCK hide #-}
@@ -176,15 +177,10 @@ prod2C ::
   Circuit a b ->
   Circuit c d ->
   Circuit (a, c) (b, d)
-prod2C (Circuit a) (Circuit c) =
-  Circuit
-    ( \((aFwd, cFwd), (bBwd, dBwd)) ->
-        let
-          (aBwd, bFwd) = a (aFwd, bBwd)
-          (cBwd, dFwd) = c (cFwd, dBwd)
-         in
-          ((aBwd, cBwd), (bFwd, dFwd))
-    )
+prod2C ab cd = circuit $ \(a, c) -> do
+  b <- ab -< a
+  d <- cd -< c
+  idC -< (b, d)
 
 --------------------------------- SIMULATION -----------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/clash-lang/clash-protocols/issues/149