### PR TITLE
Small wb related changes

### DIFF
--- a/clash-protocols/clash-protocols.cabal
+++ b/clash-protocols/clash-protocols.cabal
@@ -34,10 +34,11 @@ common common-options
     DataKinds
     DefaultSignatures
     DeriveAnyClass
-    OverloadedRecordDot
     DerivingStrategies
     LambdaCase
     NoStarIsType
+    OverloadedRecordDot
+    PackageImports
     StandaloneDeriving
     TupleSections
     TypeApplications
@@ -145,6 +146,8 @@ library
     Protocols.Wishbone
     Protocols.Wishbone.Standard
     Protocols.Wishbone.Standard.Hedgehog
+
+    Data.List.Extra
 
     -- 'testProperty' is broken upstream, it reports wrong test names
     -- TODO: test / upstream ^

--- a/clash-protocols/src/Data/List/Extra.hs
+++ b/clash-protocols/src/Data/List/Extra.hs
@@ -1,0 +1,31 @@
+{- |
+Utility functions that operate on lists, but are not part of `Data.List`.
+-}
+module Data.List.Extra where
+
+import "base" Data.List qualified as L
+
+{- |
+Takes elements from a list while the predicate holds, considers up to @window@ elements
+since the last element that satisfied the predicate.
+
+>>> takeWhileAnyInWindow 3 Prelude.odd [1, 2, 3, 6, 8, 10, 12]
+[1,2,3]
+-}
+takeWhileAnyInWindow ::
+  -- | Number of elements to consider since the last element that satisfied the predicate.
+  Int ->
+  -- | Function to test each element.
+  (a -> Bool) ->
+  -- | Input list
+  [a] ->
+  -- | List of elements that satisfied the predicate. Ends at an element that
+  -- satisfies the predicate.
+  [a]
+takeWhileAnyInWindow wdw predicate = go wdw []
+ where
+  go 0 _ _ = []
+  go cnt acc (x : xs)
+    | predicate x = L.reverse (x : acc) <> go wdw [] xs
+    | otherwise = go (pred cnt) (x : acc) xs
+  go _ _ _ = []

--- a/clash-protocols/src/Protocols/Wishbone.hs
+++ b/clash-protocols/src/Protocols/Wishbone.hs
@@ -262,9 +262,47 @@ emptyWishboneS2M =
     , stall = False
     }
 
--- | Given a tuple of a wishbone request and corresponding response, determine if the bus is active.
+{- | Given a tuple of a wishbone request and corresponding response, determine
+whether transactions are in progress(returns true for any 'hasTerminateFlag').
+This is useful to determine whether a Wishbone bus is active.
+
+>>> :{
+let m2s = (emptyWishboneM2S @32 @()){busCycle = True, strobe = True}
+    s2m = emptyWishboneS2M{acknowledge = True}
+  in hasBusActivity (m2s, s2m)
+:}
+True
+
+>>> :{
+let m2s = (emptyWishboneM2S @32 @()){busCycle = True, strobe = True}
+    s2m = emptyWishboneS2M{retry = True}
+  in hasBusActivity (m2s, s2m)
+:}
+True
+
+>>> :{
+let m2s = (emptyWishboneM2S @32 @()){busCycle = True}
+    s2m = emptyWishboneS2M{acknowledge = True}
+  in hasBusActivity (m2s, s2m)
+:}
+False
+
+>>> :{
+let m2s = (emptyWishboneM2S @32 @()){busCycle = True, strobe = True}
+    s2m = emptyWishboneS2M
+  in hasBusActivity (m2s, s2m)
+:}
+False
+
+>>> :{
+let m2s = emptyWishboneM2S @32 @()
+    s2m = emptyWishboneS2M{acknowledge = True}
+  in hasBusActivity (m2s, s2m)
+:}
+False
+-}
 hasBusActivity :: (WishboneM2S addressWidth sel dat, WishboneS2M dat) -> Bool
-hasBusActivity (m2s, s2m) = busCycle m2s || hasTerminateFlag s2m
+hasBusActivity (m2s, s2m) = busCycle m2s C.&& strobe m2s C.&& hasTerminateFlag s2m
 
 -- | Helper function to determine whether a Slave signals the termination of a cycle.
 hasTerminateFlag :: WishboneS2M dat -> Bool

--- a/clash-protocols/src/Protocols/Wishbone/Standard/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/Wishbone/Standard/Hedgehog.hs
@@ -58,6 +58,7 @@ import Clash.Prelude as C hiding (cycle, indices, not, (&&), (||))
 import Clash.Signal.Internal (Signal ((:-)))
 import Control.DeepSeq (NFData)
 import Data.Bifunctor qualified as B
+import Data.List.Extra
 import Data.String.Interpolate (i)
 import GHC.Stack (HasCallStack)
 import Hedgehog ((===))
@@ -470,30 +471,6 @@ validatorCircuitLenient =
             <> show s2m0
       Right (True, state1) -> ((cycle + 1, (m2s1, s2m1), state1), (s2m1, m2s1))
       Right (False, state1) -> go (cycle, (m2s0, s2m0), state1) (m2s1, s2m1)
-
-{- |
-Takes elements from a list while the predicate holds, considers up to @window@ elements
-since the last element that satisfied the predicate.
-
->>> takeWhileAnyInWindow 3 Prelude.odd [1, 2, 3, 6, 8, 10, 12]
-[1,2,3]
--}
-takeWhileAnyInWindow ::
-  -- | Number of elements to consider since the last element that satisfied the predicate.
-  Int ->
-  -- | Function to test each element.
-  (a -> Bool) ->
-  -- | Input list
-  [a] ->
-  -- | List of elements that satisfied the predicate. Ends at an element that satisfies the predicate.
-  [a]
-takeWhileAnyInWindow wdw predicate = go wdw []
- where
-  go 0 _ _ = []
-  go cnt acc (x : xs)
-    | predicate x = P.reverse (x : acc) <> go wdw [] xs
-    | otherwise = go (pred cnt) (x : acc) xs
-  go _ _ _ = []
 
 -- | Test a wishbone 'Standard' circuit against a pure model.
 wishbonePropWithModel ::

--- a/clash-protocols/src/Protocols/Wishbone/Standard/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/Wishbone/Standard/Hedgehog.hs
@@ -48,7 +48,6 @@ module Protocols.Wishbone.Standard.Hedgehog (
   genWishboneTransfer,
 
   -- * helpers
-  filterTransactions,
   m2sToRequest,
 )
 where
@@ -598,16 +597,6 @@ genWishboneTransfer addrRange genA = do
     [ pure $ Read (pack addr) sel
     , pure $ Write (pack addr) sel dat
     ]
-
--- | Given a list of master / slave samples, only keep the ones where an active request receives a response.
-filterTransactions ::
-  (KnownNat addressWidth, KnownNat (BitSize a), BitPack a) =>
-  [(WishboneM2S addressWidth (BitSize a `DivRU` 8) a, WishboneS2M a)] ->
-  [(WishboneM2S addressWidth (BitSize a `DivRU` 8) a, WishboneS2M a)]
-filterTransactions ((m2s, s2m) : rest)
-  | not (busCycle m2s && strobe m2s && hasTerminateFlag s2m) = filterTransactions rest
-  | otherwise = (m2s, s2m) : filterTransactions rest
-filterTransactions [] = []
 
 {- | Interpret a 'WishboneM2S' as a 'WishboneMasterRequest'.
 Only works for valid requests and performs no checks.

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Base.hs
@@ -7,7 +7,7 @@ module Tests.Protocols.PacketStream.Base (
 import Clash.Prelude
 
 import Data.List qualified as L
-import Data.List.Extra (unsnoc)
+import "extra" Data.List.Extra (unsnoc)
 
 import Hedgehog (Property)
 import Hedgehog.Gen qualified as Gen

--- a/clash-protocols/tests/Tests/Protocols/PacketStream/Padding.hs
+++ b/clash-protocols/tests/Tests/Protocols/PacketStream/Padding.hs
@@ -6,7 +6,7 @@ module Tests.Protocols.PacketStream.Padding (
 
 import Clash.Prelude
 
-import Data.List.Extra qualified as L
+import "extra" Data.List.Extra qualified as L
 
 import Hedgehog
 import Hedgehog.Gen qualified as Gen

--- a/clash-protocols/tests/Util.hs
+++ b/clash-protocols/tests/Util.hs
@@ -1,7 +1,6 @@
 module Util where
 
 -- base
-import Data.List.Extra (transpose)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- unordered-containers
@@ -18,7 +17,8 @@ import Clash.Prelude (type (<=))
 import Clash.Prelude qualified as C
 
 -- extra
-import Data.List.Extra qualified as Extra
+import "extra" Data.List.Extra (transpose)
+import "extra" Data.List.Extra qualified as Extra
 
 -- hedgehog
 import Hedgehog qualified as H


### PR DESCRIPTION
The implementation of `hasBusActivity` was wrong, `filterTransactions` bloats the API because it's the same as `filter hasBusActivity` and `takeWhileAnyInWindow` is very generic and useful outside of wishbone tests