### PR TITLE
Optimize ready signaling

### DIFF
--- a/clash-protocols/src/Protocols/PacketStream/Converters.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Converters.hs
@@ -267,11 +267,10 @@ downConverterT st@(DownConverterState{..}) (fwdIn, bwdIn) =
   -- newly received valid data and load it into our registers.
   emptyState = _dcSize == 0 && not _dcZeroByteTransfer
   readyOut =
-    isJust fwdIn
-      && (emptyState || (_dcSize <= natToNum @dwOut && _ready bwdIn))
+    emptyState || (_dcSize <= natToNum @dwOut && _ready bwdIn)
 
   nextSt
-    | readyOut = newState (fromJustX fwdIn)
+    | isJust fwdIn && readyOut = newState (fromJustX fwdIn)
     | not emptyState && _ready bwdIn =
         st
           { _dcBuf = shiftedBuf

--- a/clash-protocols/src/Protocols/PacketStream/Depacketizers.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Depacketizers.hs
@@ -192,7 +192,7 @@ depacketizerT toMetaOut st@Forward{..} (Just pkt@PacketStreamM2S{..}, bwdIn) = (
   outReady
     | Forward{_lastFwd = True} <- nextStOut = False
     | otherwise = _ready bwdIn
-depacketizerT _ st (Nothing, bwdIn) = (st, (bwdIn, Nothing))
+depacketizerT _ st (Nothing, _) = (st, (deepErrorX "undefined ack", Nothing))
 
 {- |
 Reads bytes at the start of each packet into `_meta`. If a packet contains
@@ -316,7 +316,7 @@ depacketizeToDfT toOut st@DfConsumePadding{..} (Just (PacketStreamM2S{..}), Ack 
 
   readyOut = isNothing fwdOut || readyIn
   nextStOut = if readyOut then nextSt else st
-depacketizeToDfT _ st (Nothing, Ack readyIn) = (st, (PacketStreamS2M readyIn, Nothing))
+depacketizeToDfT _ st (Nothing, _) = (st, (deepErrorX "undefined ack", Nothing))
 
 {- |
 Reads bytes at the start of each packet into a header structure, and

--- a/clash-protocols/src/Protocols/PacketStream/Padding.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Padding.hs
@@ -57,7 +57,7 @@ stripPaddingT ::
     , Maybe (PacketStreamM2S dataWidth meta)
     )
   )
-stripPaddingT _ st@Counting{} (Nothing, bwdIn) = (nextSt, (PacketStreamS2M True, fwdOut))
+stripPaddingT _ st@Counting{} (Nothing, bwdIn) = (nextSt, (deepErrorX "undefined ack", fwdOut))
  where
   fwdOut =
     if _valid st
@@ -123,7 +123,7 @@ stripPaddingT toLength st@Counting{} (Just inPkt, bwdIn) = (nextSt, (bwdOut, fwd
     | isJust fwdOut && not (_ready bwdIn) = st
     | isNothing (_last inPkt) && tooBig = Strip nextBuf
     | otherwise = Counting nextBuf nextValid nextCounter
-stripPaddingT _ st@Strip{} (Nothing, _) = (st, (PacketStreamS2M True, Nothing))
+stripPaddingT _ st@Strip{} (Nothing, _) = (st, (deepErrorX "undefined ack", Nothing))
 stripPaddingT _ Strip{_buffer = f} (Just inPkt, _) =
   (nextSt, (PacketStreamS2M True, Nothing))
  where

--- a/clash-protocols/src/Protocols/PacketStream/Routing.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Routing.hs
@@ -82,7 +82,7 @@ packetDispatcherC predicates =
   Circuit (B.second unbundle . unbundle . fmap go . bundle . B.second bundle)
  where
   idleOtp = repeat Nothing
-  go (Nothing, _) = (PacketStreamS2M False, idleOtp)
+  go (Nothing, _) = (deepErrorX "undefined ack", idleOtp)
   go (Just x, bwds) = case findIndex id (zipWith ($) predicates (pure $ _meta x)) of
     Just i -> (bwds !! i, replace i (Just x) idleOtp)
     Nothing -> (PacketStreamS2M True, idleOtp)


### PR DESCRIPTION
Many streaming components currently insist that the `O_READY` signal takes on a particular value when `I_VALID` is driven low. This introduces a combinational path between `I_VALID` and `O_READY` on the same streaming interface, which is not disallowed by any protocol specifications (as there must not be a combinational path between `I_READY` and `O_VALID`), but it is unnecessary. Driving `O_READY` as `X` (don't care) when `I_VALID` is driven low removes these paths, which is likely to ease timing closure. Especially since there is usually already a lot of logic driving these control signals.