### PR TITLE
Add typeclass instances for AXI channels

### DIFF
--- a/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/ReadAddress.hs
@@ -189,12 +189,17 @@ deriving instance
   (KnownAxi4ReadAddressConfig conf, C.BitPack user) => C.BitPack (M2S_ReadAddress conf user)
 deriving instance
   (KnownAxi4ReadAddressConfig conf, Show userType) => Show (M2S_ReadAddress conf userType)
+deriving instance
+  (KnownAxi4ReadAddressConfig conf, C.ShowX userType) =>
+  C.ShowX (M2S_ReadAddress conf userType)
+deriving instance
+  (KnownAxi4ReadAddressConfig conf, Eq userType) => Eq (M2S_ReadAddress conf userType)
 
 -- | See Table A2-5 "Read address channel signals"
 newtype S2M_ReadAddress = S2M_ReadAddress
   {_arready :: Bool}
-  deriving stock (Show, Generic)
-  deriving anyclass (C.NFDataX, C.BitPack)
+  deriving stock (Show, Generic, Eq)
+  deriving anyclass (C.ShowX, C.NFDataX, C.BitPack)
 
 {- | Shorthand for a "well-behaved" read address config,
 so that we don't need to write out a bunch of type constraints later.

--- a/clash-protocols/src/Protocols/Axi4/ReadData.hs
+++ b/clash-protocols/src/Protocols/Axi4/ReadData.hs
@@ -107,8 +107,8 @@ data
 
 -- | See Table A2-6 "Read data channel signals"
 newtype M2S_ReadData = M2S_ReadData {_rready :: Bool}
-  deriving stock (Show, Generic)
-  deriving anyclass (C.NFDataX, C.BitPack)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (C.ShowX, C.NFDataX, C.BitPack)
 
 {- | Shorthand for a "well-behaved" read data config,
 so that we don't need to write out a bunch of type constraints later.
@@ -118,6 +118,8 @@ type KnownAxi4ReadDataConfig conf =
   ( KeepTypeClass (RKeepResponse conf)
   , C.KnownNat (RIdWidth conf)
   , Show (ResponseType (RKeepResponse conf))
+  , C.ShowX (ResponseType (RKeepResponse conf))
+  , Eq (ResponseType (RKeepResponse conf))
   , C.NFDataX (ResponseType (RKeepResponse conf))
   , C.BitPack (ResponseType (RKeepResponse conf))
   )
@@ -128,6 +130,20 @@ deriving instance
   , Show dataType
   ) =>
   Show (S2M_ReadData conf userType dataType)
+
+deriving instance
+  ( KnownAxi4ReadDataConfig conf
+  , C.ShowX userType
+  , C.ShowX dataType
+  ) =>
+  C.ShowX (S2M_ReadData conf userType dataType)
+
+deriving instance
+  ( KnownAxi4ReadDataConfig conf
+  , Eq userType
+  , Eq dataType
+  ) =>
+  Eq (S2M_ReadData conf userType dataType)
 
 deriving instance
   ( KnownAxi4ReadDataConfig conf

--- a/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteAddress.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 {- |
 Defines WriteAddress channel of full AXI4 protocol with port names corresponding
@@ -182,8 +183,8 @@ data
 
 -- | See Table A2-2 "Write address channel signals"
 newtype S2M_WriteAddress = S2M_WriteAddress {_awready :: Bool}
-  deriving stock (Show, Generic)
-  deriving anyclass (C.NFDataX, C.BitPack)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (C.ShowX, C.NFDataX, C.BitPack)
 
 {- | Shorthand for a "well-behaved" write address config,
 so that we don't need to write out a bunch of type constraints later.
@@ -258,9 +259,27 @@ deriving instance
 
 deriving instance
   ( KnownAxi4WriteAddressConfig conf
+  , C.ShowX userType
+  ) =>
+  C.ShowX (M2S_WriteAddress conf userType)
+
+deriving instance
+  ( KnownAxi4WriteAddressConfig conf
   , C.NFDataX userType
   ) =>
   C.NFDataX (M2S_WriteAddress conf userType)
+
+deriving instance
+  ( KnownAxi4WriteAddressConfig conf
+  , Eq userType
+  ) =>
+  Eq (M2S_WriteAddress conf userType)
+
+deriving instance
+  ( KnownAxi4WriteAddressConfig conf
+  , C.BitPack userType
+  ) =>
+  C.BitPack (M2S_WriteAddress conf userType)
 
 {- | Mainly for use in @DfConv@.
 

--- a/clash-protocols/src/Protocols/Axi4/WriteData.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteData.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 {- |
 Defines WriteData channel of full AXI4 protocol with port names corresponding
@@ -111,7 +112,9 @@ Holds for every configuration; don't worry about implementing this class.
 type KnownAxi4WriteDataConfig conf =
   ( KeepStrobeClass (WKeepStrobe conf)
   , C.KnownNat (WNBytes conf)
+  , Eq (StrobeDataType (WKeepStrobe conf))
   , Show (StrobeDataType (WKeepStrobe conf))
+  , C.ShowX (StrobeDataType (WKeepStrobe conf))
   , C.NFDataX (StrobeDataType (WKeepStrobe conf))
   , C.BitPack (StrobeDataType (WKeepStrobe conf))
   )
@@ -121,6 +124,24 @@ deriving instance
   , Show userType
   ) =>
   Show (M2S_WriteData conf userType)
+
+deriving instance
+  ( KnownAxi4WriteDataConfig conf
+  , C.ShowX userType
+  ) =>
+  C.ShowX (M2S_WriteData conf userType)
+
+deriving instance
+  ( KnownAxi4WriteDataConfig conf
+  , Eq userType
+  ) =>
+  Eq (M2S_WriteData conf userType)
+
+deriving instance
+  ( KnownAxi4WriteDataConfig conf
+  , C.BitPack userType
+  ) =>
+  C.BitPack (M2S_WriteData conf userType)
 
 deriving instance
   ( KnownAxi4WriteDataConfig conf

--- a/clash-protocols/src/Protocols/Axi4/WriteResponse.hs
+++ b/clash-protocols/src/Protocols/Axi4/WriteResponse.hs
@@ -86,8 +86,8 @@ data
 
 -- | See Table A2-4 "Write response channel signals"
 newtype M2S_WriteResponse = M2S_WriteResponse {_bready :: Bool}
-  deriving stock (Show, Generic)
-  deriving anyclass (C.NFDataX, C.BitPack)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (C.ShowX, C.NFDataX, C.BitPack)
 
 {- | Shorthand for a "well-behaved" write response config,
 so that we don't need to write out a bunch of type constraints later.
@@ -96,16 +96,36 @@ Holds for every configuration; don't worry about implementing this class.
 type KnownAxi4WriteResponseConfig conf =
   ( KeepTypeClass (BKeepResponse conf)
   , C.KnownNat (BIdWidth conf)
+  , Eq (ResponseType (BKeepResponse conf))
   , Show (ResponseType (BKeepResponse conf))
+  , C.ShowX (ResponseType (BKeepResponse conf))
   , C.NFDataX (ResponseType (BKeepResponse conf))
   , C.BitPack (ResponseType (BKeepResponse conf))
   )
 
 deriving instance
   ( KnownAxi4WriteResponseConfig conf
+  , Eq userType
+  ) =>
+  Eq (S2M_WriteResponse conf userType)
+
+deriving instance
+  ( KnownAxi4WriteResponseConfig conf
   , Show userType
   ) =>
   Show (S2M_WriteResponse conf userType)
+
+deriving instance
+  ( KnownAxi4WriteResponseConfig conf
+  , C.BitPack userType
+  ) =>
+  C.BitPack (S2M_WriteResponse conf userType)
+
+deriving instance
+  ( KnownAxi4WriteResponseConfig conf
+  , C.ShowX userType
+  ) =>
+  C.ShowX (S2M_WriteResponse conf userType)
 
 deriving instance
   ( KnownAxi4WriteResponseConfig conf


### PR DESCRIPTION
Ensures all underlying types for the AXI4 channels:
* ReadAddress
* ReadData
* WriteAddress
* WriteData
* WriteResponse

Have instances for: `Eq`, `ShowX`, `BitPack`, `NFDataX`