### PR TITLE
Add automatic package pushing to binary caches

### DIFF
--- a/.ci/attic-auth.sh
+++ b/.ci/attic-auth.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -uo pipefail
+
+mkdir -p ~/.config/attic
+cat <<EOF > ~/.config/attic/config.toml
+default-server = "public"
+
+[servers.public]
+endpoint = "http://192.168.102.136:9200"
+token = "$ATTIC_AUTH_TOKEN"
+EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Stack / GHC
         uses: haskell-actions/setup@v2
@@ -35,7 +35,7 @@ jobs:
           stack config set system-ghc --global true
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: ${{ steps.setup-haskell.outputs.stack-root }}
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
@@ -94,7 +94,7 @@ jobs:
           mv cabal.project.freeze frozen
 
       - name: Restore cached dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
@@ -120,8 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Note that you must checkout your code before running haskell-actions/run-fourmolu
-      - uses: actions/checkout@v3
-      - uses: haskell-actions/run-fourmolu@v9
+      - uses: actions/checkout@v6
+      - uses: haskell-actions/run-fourmolu@v12
         with:
           version: "0.19.0.1"
           pattern: |
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Whitespace
         run: |
@@ -147,7 +147,7 @@ jobs:
         ghc-version: [ "ghc9124", "ghc9103", "ghc984", "ghc967" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build & test
         run: |
@@ -187,7 +187,7 @@ jobs:
         # If dependencies are already cached, we can simply reuse them!
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build devshell
         run: |
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check dependencies for failures
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   stack:
     name: Stack tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,11 +50,10 @@ jobs:
 
   cabal:
     name: Cabal tests - ghc ${{ matrix.ghc }} / clash ${{ matrix.clash }} / doc ${{ matrix.check_haddock }}
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         clash:
           - "1.10.0"
         cabal:
@@ -67,7 +66,6 @@ jobs:
           - check_haddock: "False"
           - ghc: "9.6.7"
             check_haddock: "True"
-            os: "ubuntu-latest"
             clash: "1.10.0"
             cabal: "3.14.1.1"
 
@@ -141,6 +139,82 @@ jobs:
         run: |
           .ci/test_whitespace.sh
 
+  packages:
+    name: Push package to cache
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        ghc-version: [ "ghc9124", "ghc9103", "ghc984", "ghc967" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build & test
+        run: |
+          # The -L flag outputs build logs to stderr
+          nix build -L .#${{ matrix.ghc-version }}.clash-protocols-base
+          nix build -L .#${{ matrix.ghc-version }}.clash-protocols
+
+        # Pushes the binaries to the local network
+        # url: http://192.168.102.136:9200/public
+        # public key: public:Wne+du2QhXD0O30YJ93NxG8xJRdfHvFQgKU0XVgENsg=
+      - name: Push package to cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: |
+          .ci/attic-auth.sh
+          attic push public $(nix path-info .#${{ matrix.ghc-version }}.clash-protocols-base)
+          attic push public $(nix path-info .#${{ matrix.ghc-version }}.clash-protocols)
+
+      - name: Push package to cachix
+        if: github.ref == 'refs/heads/main'
+        env:
+          # Having the variable be named `CACHIX_AUTH_TOKEN` authenticates cachix
+          # https://docs.cachix.org/getting-started#authenticating
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
+        run: |
+          nix path-info .#${{ matrix.ghc-version }}.clash-protocols-base | cachix push clash-lang
+          nix path-info .#${{ matrix.ghc-version }}.clash-protocols | cachix push clash-lang
+
+  devshells:
+    name: Push Nix developer shell to cache
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        ghc-version: [ "ghc9124", "ghc9103", "ghc984", "ghc967" ]
+    steps:
+        # There's no need to configure Nix, the dockerfile handling the GHA has it done for us!
+        # If dependencies are already cached, we can simply reuse them!
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build devshell
+        run: |
+          # Since the server is x86_64-linux, we can only build the devshell
+          # for that
+          nix build -L .#devShells.x86_64-linux.${{ matrix.ghc-version }}-full
+
+        # Pushes the binaries to the local network
+        # url: http://192.168.102.136:9200/public
+        # public key: public:Wne+du2QhXD0O30YJ93NxG8xJRdfHvFQgKU0XVgENsg=
+      - name: Push devshell to cache
+        env:
+          ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_SECRET }}
+        run: |
+          .ci/attic-auth.sh
+          attic push public $(nix path-info .#devShells.x86_64-linux.${{ matrix.ghc-version }}-full)
+
+        # Pushes the binaries to Cachix
+      - name: Push devshell to cachix
+        if: github.ref == 'refs/heads/main'
+        env:
+          # Having the variable be named `CACHIX_AUTH_TOKEN` authenticates cachix
+          # https://docs.cachix.org/getting-started#authenticating
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_SECRET }}
+        run: |
+          nix path-info .#devShells.x86_64-linux.${{ matrix.ghc-version }}-full | cachix push clash-lang
+
   # Mandatory check on GitHub
   all:
     name: All jobs finished
@@ -150,8 +224,10 @@ jobs:
         fourmolu,
         linting,
         stack,
+        packages,
+        devshells,
       ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -668,6 +668,36 @@ in
 
 And that's it!
 
+### Cache
+
+Compiling Clash can take quite some time. To remedy the situation, we maintain a Cachix cache which can be used to speed up compilation. To add the cache, first (temporarily) install cachix:
+
+`nix shell nixpkgs#cachix`
+
+And then run:
+
+`cachix use clash-lang`
+
+And that's it! The cache is now set up and you no longer need cachix installed.
+
+Alternatively you can add the cache manually to your `nix.conf` file. Simply add the following two configurations:
+```conf
+extra-substituters = https://clash-lang.cachix.org
+extra-trusted-public-keys = clash-lang.cachix.org-1:/2N1uka38B/heaOAC+Ztd/EWLmF0RLfizWgC5tamCBg=
+```
+If a project specific cache is preferred, using a `flake.nix` with the following will only make the cache active for the specific project of the flake:
+```nix
+{
+  nixConfig = {
+    extra-substituters = [ "https://clash-lang.cachix.org" ];
+    extra-trusted-public-keys = [ "clash-lang.cachix.org-1:/2N1uka38B/heaOAC+Ztd/EWLmF0RLfizWgC5tamCBg=" ];
+  };
+  description = ...;
+  inputs = ...;
+  outputs = ...;
+}
+```
+
 # TODO
 
 0.1

--- a/clash-protocols/tests/Tests/Protocols/Avalon.hs
+++ b/clash-protocols/tests/Tests/Protocols/Avalon.hs
@@ -219,7 +219,7 @@ tests :: TestTree
 tests =
   -- TODO: Move timeout option to hedgehog for better error messages.
   -- TODO: Does not seem to work for combinatorial loops like @let x = x in x@??
-  localOption (mkTimeout 12_000_000 {- 12 seconds -}) $
+  localOption (mkTimeout 60_000_000 {- 60 seconds -}) $
     localOption
       (HedgehogTestLimit (Just 1000))
       $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/Axi4.hs
+++ b/clash-protocols/tests/Tests/Protocols/Axi4.hs
@@ -353,7 +353,7 @@ tests :: TestTree
 tests =
   -- TODO: Move timeout option to hedgehog for better error messages.
   -- TODO: Does not seem to work for combinatorial loops like @let x = x in x@??
-  localOption (mkTimeout 12_000_000 {- 12 seconds -}) $
+  localOption (mkTimeout 60_000_000 {- 60 seconds -}) $
     localOption
       (HedgehogTestLimit (Just 1000))
       $(testGroupGenerator)

--- a/clash-protocols/tests/Tests/Protocols/Df.hs
+++ b/clash-protocols/tests/Tests/Protocols/Df.hs
@@ -604,7 +604,7 @@ tests :: TestTree
 tests =
   -- TODO: Move timeout option to hedgehog for better error messages.
   -- TODO: Does not seem to work for combinatorial loops like @let x = x in x@??
-  localOption (mkTimeout 12_000_000 {- 12 seconds -}) $
+  localOption (mkTimeout 60_000_000 {- 60 seconds -}) $
     localOption
       (HedgehogTestLimit (Just 1000))
       $(testGroupGenerator)


### PR DESCRIPTION
Makes CI automatically push packages to the binary cache for commits on the main branch. This way the caches always contain the latest versions. It also updates the documentation to include a small chapter about how to include Cachix to use the cache. Both the developer shell and the package itself get cached.

Practically a 1:1 copy of https://github.com/clash-lang/clash-cores/pull/48
