### PR TITLE
Add `Df.toMaybe` and `Df.unsafeFromMaybe`

### DIFF
--- a/clash-protocols/src/Protocols/Df.hs
+++ b/clash-protocols/src/Protocols/Df.hs
@@ -3,6 +3,7 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
 {- |
 Defines data structures and operators to create a Dataflow protocol that only
@@ -68,6 +69,8 @@ module Protocols.Df (
   registerFwd,
   registerBwd,
   fifo,
+  toMaybe,
+  unsafeFromMaybe,
 
   -- * Simulation functions
   drive,
@@ -930,6 +933,58 @@ fifo fifoDepth = Circuit $ C.hideReset circuitFunction
   -- (space left = depth) or full (space left = 0).
   s0 :: (C.Index depth, C.Index depth, C.Index (depth C.+ 1))
   s0 = (0, 0, maxBound)
+
+-- | Convert a 'Df' stream to a 'Maybe' stream. Never stalls LHS.
+toMaybe :: Circuit (Df dom a) (CSignal dom (Maybe a))
+toMaybe = Circuit $ \(maybes, _) -> (C.pure (Ack True), maybes)
+
+{- | Convert a 'Maybe' stream to a 'Df' stream. Not every 'Just' is guaranteed to
+be forwarded to the RHS. The number of dropped 'Just's is exported as an
+unsigned number. Note that this circuit needs a clock to latch the incoming
+'Maybe' values in case of backpressure from the RHS.
+-}
+unsafeFromMaybe ::
+  forall n a dom.
+  ( C.HiddenClockResetEnable dom
+  , C.NFDataX a
+  , C.KnownNat n
+  ) =>
+  Circuit
+    (CSignal dom (Maybe a))
+    ( Df dom a
+    , CSignal dom (C.Unsigned n)
+    )
+unsafeFromMaybe = circuit $ \maybes -> do
+  (as0, droppeds) <- Circuit go2 -< maybes
+  as1 <- forceResetSanity -< as0
+  idC -< (as1, droppeds)
+ where
+  go2 ::
+    (Signal dom (Maybe a), (Signal dom Ack, Signal dom ())) ->
+    (Signal dom (), (Signal dom (Maybe a), Signal dom (C.Unsigned n)))
+  go2 (fwdA, (ackB, _)) = (C.pure (), C.mealyB go1 (Nothing, 0) (fwdA, ackB))
+
+  go1 ::
+    (Maybe a, C.Unsigned n) ->
+    (Maybe a, Ack) ->
+    ( (Maybe a, C.Unsigned n)
+    , (Maybe a, C.Unsigned n)
+    )
+  go1 (s0, !n0) ~(i, ~(Ack ack)) = ((s1, n1), (o, n1))
+   where
+    -- We're dropping a value if we have a stored value (s0), the LHS sends a
+    -- new value (i), and the RHS does not acknowledge (not ack).
+    n1
+      | Maybe.isJust s0 && Maybe.isJust i && not ack = n0 + 1
+      | otherwise = n0
+
+    o = s0 <|> i
+
+    s1
+      | Maybe.isJust s0 && not ack = s0
+      | Maybe.isJust s0 && ack = i
+      | Maybe.isJust i && ack = Nothing
+      | otherwise = i
 
 --------------------------------- SIMULATE -------------------------------------
 


### PR DESCRIPTION
We sometimes want to:

 * Convert a `Df` into signal of `Maybe`: we're just interested in the most recent value, and will never produce backpressure. Introducing: `toMaybe`.
 * Convert a signal of `Maybe`s into `Df`: we're just interested in feeding the most recent value. This is non-trivial due to `Df` requiring that the value on its `Fwd` must be stable until acked. Introducing: `unsafeFromMaybe`.

This does change the type signature of `toMaybe`, but that should be okay given that it was marked internal anyway.