### PR TITLE
Workaround ghc-typelits-extra#68

### DIFF
--- a/clash-protocols/src/Data/Constraint/Nat/Extra.hs
+++ b/clash-protocols/src/Data/Constraint/Nat/Extra.hs
@@ -17,8 +17,13 @@ leModulusDivisor :: forall a b. (1 <= b) => Dict (Mod a b + 1 <= b)
 leModulusDivisor = unsafeCoerce (Dict :: Dict (0 <= 0))
 
 -- | if (1 <= a) and (1 <= b) then (1 <= DivRU a b)
-strictlyPositiveDivRu :: forall a b. (1 <= a, 1 <= b) => Dict (1 <= DivRU a b)
-strictlyPositiveDivRu = unsafeCoerce (Dict :: Dict (0 <= 0))
+strictlyPositiveDivRu ::
+  forall a b.
+  (1 <= a, 1 <= b) =>
+  -- | XXX: The 'Constraint' equality is there to work around
+  -- issue github.com/clash-lang/ghc-typelits-extra/issues/68.
+  Dict ((1 <= DivRU a b) ~ (() :: Constraint))
+strictlyPositiveDivRu = unsafeCoerce (Dict :: Dict (() ~ ()))
 
 -- | if (1 <= a) then (b <= ceil(b/a) * a)
 leTimesDivRu :: forall a b. (1 <= a) => Dict (b <= a * DivRU b a)

--- a/clash-protocols/src/Protocols/PacketStream/Packetizers.hs
+++ b/clash-protocols/src/Protocols/PacketStream/Packetizers.hs
@@ -358,7 +358,9 @@ packetizeFromDfT ::
   (KnownNat headerBytes) =>
   (KnownNat dataWidth) =>
   (1 <= dataWidth) =>
-  (1 <= headerBytes `DivRU` dataWidth) =>
+  -- \| XXX: The 'Constraint' equality is there to work around
+  -- issue github.com/clash-lang/ghc-typelits-extra/issues/68.
+  ((1 <= headerBytes `DivRU` dataWidth) ~ (() :: Constraint)) =>
   ((dataWidth + 1) <= headerBytes) =>
   -- | Mapping from `Df` input to output `_meta`
   (a -> metaOut) ->


### PR DESCRIPTION
See https://github.com/clash-lang/ghc-typelits-extra/issues/68

This currently breaks compiles over at `clash-cores`. See https://github.com/clash-lang/clash-cores/pull/56.