### PR TITLE
Add default implementation for `Fwd` and `Bwd`

### DIFF
--- a/clash-protocols-base/src/Protocols/Plugin/Types.hs
+++ b/clash-protocols-base/src/Protocols/Plugin/Types.hs
@@ -19,9 +19,13 @@ class Protocol a where
   -- existence of 'Fwd'.
   type Fwd (a :: Type)
 
+  type Fwd a = a
+
   -- | Receiver to sender type family. See 'Circuit' for an explanation on the
   -- existence of 'Bwd'.
   type Bwd (a :: Type)
+
+  type Bwd a = ()
 
 {- | A /Circuit/, in its most general form, corresponds to a component with two
 pairs of an input and output. As a diagram:


### PR DESCRIPTION
The more I use `Circuit`s, the more I use the following pattern to "lift" types containing signals to circuit notation:

```haskell
data Input dom = Input
  { coreReset :: Reset dom
  , subCoreReset :: Reset dom
  , wibbles :: Signal dom (Unsigned 64)
  , wobbles :: Signal dom (Unsigned 64)
  }
```

I mostly do that to get away from positional arguments / boolean(like) blindness. Lifting that to `Circuit` then looks like:

```haskell
instance Protocol (Input dom) where
  type Fwd (Input dom) = Input dom
  type Bwd (Input dom) = ()

instance Protocol (Output dom) where
  type Fwd (Output dom) = Output dom
  type Bwd (Output dom) = ()
```

..at which point I can conveniently use it using `Fwd` and friends. To me this sounds like a sensible default implementation.