### PR TITLE
Fix `stallStandard`, the implementation did not work at all.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/clash-protocols/src/Protocols/Experimental/Wishbone/Standard.hs
+++ b/clash-protocols/src/Protocols/Experimental/Wishbone/Standard.hs
@@ -8,7 +8,18 @@ import Clash.Prelude
 import Data.Bifunctor qualified as B
 import Protocols
 import Protocols.Experimental.Wishbone
-import Prelude hiding (head, not, repeat, (!!), (&&), (||))
+import Prelude hiding (
+  head,
+  map,
+  not,
+  repeat,
+  reverse,
+  zipWith,
+  zipWith3,
+  (!!),
+  (&&),
+  (||),
+ )
 
 -- | Distribute requests amongst N slave circuits
 roundrobin ::
@@ -147,3 +158,23 @@ memoryWb ram = Circuit go
     isWrite = managerActive && m2s.writeEnable
     isRead = managerActive && not (m2s.writeEnable)
     write = Just (m2s.addr, m2s.writeData)
+
+{- | Latch the response from the slave when a transaction is completed. This is
+useful for circuits that need the response for more than one cycle.
+As soon as the manager sets `busCycle`, the latched response will be dropped.
+-}
+latchResponse ::
+  forall dom addressBits dataBytes.
+  ( HiddenClockResetEnable dom
+  , KnownNat dataBytes
+  ) =>
+  Circuit
+    (Wishbone dom 'Standard addressBits dataBytes)
+    (Wishbone dom 'Standard addressBits dataBytes)
+latchResponse = Circuit goS
+ where
+  goS (m2s, s2m) = (s2m', m2s)
+   where
+    cond = m2s.busCycle
+    stored = regEn emptyWishboneS2M cond s2m
+    s2m' = mux cond s2m stored

--- a/clash-protocols/src/Protocols/Experimental/Wishbone/Standard.hs
+++ b/clash-protocols/src/Protocols/Experimental/Wishbone/Standard.hs
@@ -178,3 +178,51 @@ latchResponse = Circuit goS
     cond = m2s.busCycle
     stored = regEn emptyWishboneS2M cond s2m
     s2m' = mux cond s2m stored
+
+{- | Splits a master bus into multiple slaves based on the bus select signal.
+The circuit will send the transaction to all slaves where each slave gets their respective part
+of the byte enables and write data. The circuit utilizes 'latchResponse' to ensure all responses
+are available when the last slave responds. The circuit contains a register that ensures
+the transaction is only sent once by deasserting strobe after the slave has responded.
+-}
+splitOnMask ::
+  forall dom addressBits width nSubs.
+  ( HiddenClockResetEnable dom
+  , KnownNat addressBits
+  , KnownNat nSubs
+  , KnownNat width
+  ) =>
+  Circuit
+    (Wishbone dom 'Standard addressBits (nSubs * width))
+    (Vec nSubs (Wishbone dom 'Standard addressBits width))
+splitOnMask =
+  Circuit (B.second unbundle . mealyB go (repeat False) . B.second bundle)
+    |> repeatC latchResponse
+ where
+  go transactionDones (m2s, s2ms) = (newTransactionDones, (s2m, m2ss1))
+   where
+    allDone = all hasTerminateFlag s2ms
+
+    newTransactionDones
+      | not m2s.busCycle = repeat False
+      | allDone = repeat False
+      | otherwise = zipWith (||) transactionDones (fmap hasTerminateFlag s2ms)
+
+    readData = pack $ fmap (.readData) s2ms
+    acknowledge = all (.acknowledge) s2ms
+    err = any (.err) s2ms
+    s2m
+      | m2s.busCycle && allDone =
+          (emptyWishboneS2M @(nSubs * width)){readData, acknowledge, err}
+      | otherwise = emptyWishboneS2M
+
+    selectLanes i =
+      m2s
+        { busSelect = resize $ shiftR (m2s.busSelect) (fromIntegral i * natToNum @width)
+        , writeData = resize $ shiftR (m2s.writeData) (fromIntegral i * natToNum @width * 8)
+        }
+    m2ss0 = fmap selectLanes (reverse indicesI)
+    m2ss1 = zipWith goM transactionDones m2ss0
+    goM transactionDone m2s'
+      | transactionDone = m2s'{strobe = False}
+      | otherwise = m2s'

--- a/clash-protocols/src/Protocols/Experimental/Wishbone/Standard/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/Experimental/Wishbone/Standard/Hedgehog.hs
@@ -62,7 +62,6 @@ import Clash.Hedgehog.Sized.Unsigned (genUnsigned)
 import Clash.Prelude as C hiding (cycle, indices, not, sample, (&&), (||))
 import Clash.Signal.Internal (Signal ((:-)))
 import Control.DeepSeq (NFData)
-import Data.Bifunctor qualified as B
 import Data.List.Extra
 import Data.String.Interpolate (i)
 import GHC.Stack (HasCallStack)
@@ -303,83 +302,54 @@ stallStandard ::
   , C.KnownDomain dom
   , C.KnownNat dataBytes
   ) =>
+  {- | Early busCycle propagation, when 'True', the busCycle signal will always be propagated.
+  When 'False', the busCycle signal will be stalled just like the 'strobe' signal.
+  -}
+  Bool ->
   -- | Number of cycles to stall the master for on each valid bus-cycle
   [Int] ->
   Circuit
     (Wishbone dom 'Standard addressBits dataBytes)
     (Wishbone dom 'Standard addressBits dataBytes)
-stallStandard stallsPerCycle =
-  Circuit $
-    B.second (emptyWishboneM2S :-)
-      . uncurry (go stallsPerCycle Nothing)
+stallStandard earlyBusCycle stalls0 =
+  Circuit goS
  where
+  goS (m2s, s2m) = (s2m, go stalls0 m2s s2m)
   go ::
     [Int] ->
-    Maybe (WishboneS2M dataBytes) ->
     Signal dom (WishboneM2S addressBits dataBytes) ->
     Signal dom (WishboneS2M dataBytes) ->
-    ( Signal dom (WishboneS2M dataBytes)
-    , Signal dom (WishboneM2S addressBits dataBytes)
-    )
+    Signal dom (WishboneM2S addressBits dataBytes)
+  -- Idle, waiting for a request
+  go (stall : stalls) (m :- ms) (s :- ss) = m' :- go stalls' ms ss
+   where
+    -- Only propagate the buscycle while stalling, this allows the manager to reserve the bus, but postpones the actual
+    -- transaction until the stall is over.
+    m'
+      | stall > 0 = block m
+      | otherwise = m
+    stalls' = nextStall stall stalls m s
+  go [] ms _ = ms
 
-  go [] lastRep (_ :- m2s) ~(_ :- s2m) =
-    B.bimap (emptyWishboneS2M :-) (emptyWishboneM2S :-) $ go [] lastRep m2s s2m
-  go (st : stalls) lastRep (m :- m2s) ~(_ :- s2m)
-    -- not in a bus cycle, just pass through
-    | not (busCycle m) =
-        B.bimap
-          (emptyWishboneS2M :-)
-          (emptyWishboneM2S :-)
-          (go (st : stalls) lastRep m2s s2m)
-  go (st : stalls) Nothing (m :- m2s) ~(s :- s2m)
-    -- received a reply but still need to stall
-    | busCycle m && strobe m && st > 0 && hasTerminateFlag s =
-        B.bimap
-          -- tell the master that the slave has no reply yet
-          (emptyWishboneS2M :-)
-          -- tell the slave that the cycle is over
-          (emptyWishboneM2S :-)
-          (go (st - 1 : stalls) (Just s) m2s s2m)
-    -- received a reply but still need to stall
-    | busCycle m && strobe m && st > 0 && not (hasTerminateFlag s) =
-        B.bimap
-          -- tell the master that the slave has no reply yet
-          (emptyWishboneS2M :-)
-          -- tell the slave that the cycle is over
-          (m :-)
-          (go (st - 1 : stalls) Nothing m2s s2m)
-    -- done stalling, got a reply last second, pass through
-    | busCycle m && strobe m && st == 0 && hasTerminateFlag s =
-        B.bimap
-          (s :-)
-          (m :-)
-          (go stalls Nothing m2s s2m)
-    -- done stalling but no termination signal yet, just pass through to give the slave
-    -- the chance to reply
-    | busCycle m && strobe m && st == 0 && not (hasTerminateFlag s) =
-        B.bimap
-          (emptyWishboneS2M :-)
-          (m :-)
-          (go (0 : stalls) Nothing m2s s2m)
-    -- master cancelled cycle
-    | otherwise = B.bimap (emptyWishboneS2M :-) (m :-) (go stalls Nothing m2s s2m)
-  go (st : stalls) (Just rep) (m :- m2s) ~(_ :- s2m)
-    -- need to keep stalling, already got the reply
-    | busCycle m && strobe m && st > 0 =
-        B.bimap
-          -- keep stalling
-          (emptyWishboneS2M :-)
-          -- tell the slave that the cycle is over
-          (emptyWishboneM2S :-)
-          (go (st - 1 : stalls) (Just rep) m2s s2m)
-    -- done stalling, give reply
-    | busCycle m && strobe m && st == 0 =
-        B.bimap
-          (rep :-)
-          (emptyWishboneM2S :-)
-          (go stalls Nothing m2s s2m)
-    -- master cancelled cycle
-    | otherwise = B.bimap (emptyWishboneS2M :-) (m :-) (go stalls Nothing m2s s2m)
+  -- Select the correct implementation of the blocking logic based on earlyBusCycle.
+  block
+    | earlyBusCycle = \m -> m{strobe = False}
+    | otherwise = \m -> m{busCycle = False, strobe = False}
+
+  -- Select the correct implementation of the stalling logic based on earlyBusCycle.
+  nextStall
+    -- Don't decrement the counter if strobe is not set.
+    | earlyBusCycle = \stall stalls m s ->
+        if
+          | m.busCycle && m.strobe && hasTerminateFlag s -> stalls
+          | m.busCycle && m.strobe && stall > 0 -> stall - 1 : stalls
+          | otherwise -> stall : stalls
+    -- Decrement the counter as soon as busCycle is asserted.
+    | otherwise = \stall stalls m s ->
+        if
+          | m.busCycle && m.strobe && hasTerminateFlag s -> stalls
+          | m.busCycle && stall > 0 -> stall - 1 : stalls
+          | otherwise -> stall : stalls
 
 data DriverState addressBits dataBytes
   = -- | State in which the driver still needs to perform N resets

--- a/clash-protocols/src/Protocols/Experimental/Wishbone/Standard/Hedgehog.hs
+++ b/clash-protocols/src/Protocols/Experimental/Wishbone/Standard/Hedgehog.hs
@@ -314,22 +314,22 @@ stallStandard ::
 stallStandard earlyBusCycle stalls0 =
   Circuit goS
  where
-  goS (m2s, s2m) = (s2m, go stalls0 m2s s2m)
+  goS (m2s, s2m) = unbundle $ go stalls0 m2s s2m
   go ::
     [Int] ->
     Signal dom (WishboneM2S addressBits dataBytes) ->
     Signal dom (WishboneS2M dataBytes) ->
-    Signal dom (WishboneM2S addressBits dataBytes)
+    Signal dom (WishboneS2M dataBytes, WishboneM2S addressBits dataBytes)
   -- Idle, waiting for a request
-  go (stall : stalls) (m :- ms) (s :- ss) = m' :- go stalls' ms ss
+  go (stall : stalls) (m :- ms) (s :- ss) = response :- go stalls' ms ss
    where
     -- Only propagate the buscycle while stalling, this allows the manager to reserve the bus, but postpones the actual
     -- transaction until the stall is over.
-    m'
-      | stall > 0 = block m
-      | otherwise = m
+    response
+      | stall > 0 = (emptyWishboneS2M, block m)
+      | otherwise = (s, m)
     stalls' = nextStall stall stalls m s
-  go [] ms _ = ms
+  go [] ms ss = bundle (ss, ms)
 
   -- Select the correct implementation of the blocking logic based on earlyBusCycle.
   block

--- a/clash-protocols/tests/Tests/Protocols/Wishbone.hs
+++ b/clash-protocols/tests/Tests/Protocols/Wishbone.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
 
 module Tests.Protocols.Wishbone where
 
@@ -20,11 +21,13 @@ import Hedgehog
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Protocols
-import Protocols.Experimental.Hedgehog (defExpectOptions, eoResetCycles, eoSampleMax)
+import Protocols.Experimental.Hedgehog (ExpectOptions (..), defExpectOptions)
+import Protocols.Experimental.Simulate
 import Protocols.Experimental.Wishbone
 import Protocols.Experimental.Wishbone.Standard
 import Protocols.Experimental.Wishbone.Standard.Hedgehog
 import Protocols.Experimental.Wishbone.Standard.Hedgehog qualified as WbStd
+import Protocols.Internal (circuitMonitor)
 import Test.Tasty
 import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
 import Test.Tasty.Hedgehog.Extra (testProperty)
@@ -433,6 +436,66 @@ prop_splitOnMask = property $ do
   footnote $ [i| Expected: #{expected}|]
   footnote $ [i| Actual: #{actual}|]
   assert (and $ L.zipWith3 eqWishboneS2M reqs actual expected)
+
+--
+-- stallStandard
+
+-- | Check whether stallStandard actually stalls the outgoing bus using 'memoryWb' as subordinate.
+prop_stallStandard_early :: Property
+prop_stallStandard_early = property $ do
+  reqs <- forAll $ genData (genWishboneTransfer @8 @4 Range.linearBounded)
+  earlyBusCycle <- forAll Gen.bool
+  driveStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  memStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  let
+    eOpts = defExpectOptions{eoSampleMax = 10_000}
+    simConfig = def{timeoutAfter = 10_000}
+    reqPairs = L.zip reqs driveStalls
+
+    (preStall, postStall) =
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ sampleC simConfig
+        $ let
+            monitoredCircuit = circuit $ \wb -> do
+              (wb1, preSig) <- circuitMonitor -< wb
+              wb2 <- stallStandard earlyBusCycle memStalls -< wb1
+              (wb3, postSig) <- circuitMonitor -< wb2
+              memoryWb (blockRam (C.replicate d256 0)) -< wb3
+              idC -< (preSig, postSig)
+           in
+            driveStandard eOpts reqPairs |> monitoredCircuit
+
+    verifyStalls (n : stalls) trace =
+      let
+        active = L.dropWhile (\(pre, _) -> not (busCycle pre && strobe pre)) trace
+
+        (stallCycles, afterStall) = L.splitAt n active
+
+        -- busCycle asserted, strobe deasserted.
+        stallOk =
+          L.map
+            ( \(_pre, (post, _s2m)) ->
+                not (strobe post) && busCycle post == earlyBusCycle
+            )
+            stallCycles
+
+        -- busCycle and strobe asserted.
+        (waitCycles, termAndRest) = L.span (\(_, (_, s2m)) -> not (hasTerminateFlag s2m)) afterStall
+        waitOk = L.map (\(_pre, (post, _s2m)) -> busCycle post && strobe post) waitCycles
+
+        -- Termination cycle and remaining samples.
+        (termOk, rest) = case termAndRest of
+          ((_pre, (post, _s2m)) : rs) -> ([busCycle post && strobe post], rs)
+          [] -> ([], [])
+       in
+        L.concat [stallOk, waitOk, termOk, verifyStalls stalls rest]
+    verifyStalls [] _ = []
+
+    checks = verifyStalls memStalls (L.zip (L.map fst preStall) postStall)
+
+  footnote [i| earlyBusCycle: #{earlyBusCycle}|]
+  footnote [i| memStalls: #{memStalls}|]
+  assert $ and checks
 
 tests :: TestTree
 tests =

--- a/clash-protocols/tests/Tests/Protocols/Wishbone.hs
+++ b/clash-protocols/tests/Tests/Protocols/Wishbone.hs
@@ -471,6 +471,7 @@ prop_stallStandard_early = property $ do
 
         (stallCycles, afterStall) = L.splitAt n active
 
+        traceNonEmpty = not $ null trace
         -- busCycle asserted, strobe deasserted.
         stallOk =
           L.map
@@ -488,7 +489,7 @@ prop_stallStandard_early = property $ do
           ((_pre, (post, _s2m)) : rs) -> ([busCycle post && strobe post], rs)
           [] -> ([], [])
        in
-        L.concat [stallOk, waitOk, termOk, verifyStalls stalls rest]
+        L.concat [[traceNonEmpty], stallOk, waitOk, termOk, verifyStalls stalls rest]
     verifyStalls [] _ = []
 
     checks = verifyStalls memStalls (L.zip (L.map fst preStall) postStall)

--- a/clash-protocols/tests/Tests/Protocols/Wishbone.hs
+++ b/clash-protocols/tests/Tests/Protocols/Wishbone.hs
@@ -8,6 +8,8 @@ module Tests.Protocols.Wishbone where
 
 import Clash.Prelude as C
 
+import Clash.Hedgehog.Sized.Vector (genVec)
+import Clash.Sized.Vector.ToTuple (vecToTuple)
 import Control.DeepSeq (force)
 import Control.Exception (SomeException, evaluate, try)
 import Control.Monad.IO.Class (MonadIO (liftIO))
@@ -364,6 +366,73 @@ prop_latchResponse_retains = property $ do
 
   footnoteShow trace
   assert $ and checks
+
+--
+-- splitOnMask
+--
+
+{- | We test splitOnMask by checking if we can use it to create a byte addresable version of 'memoryWb'.
+To do so we generate arbitrary wishbone transactions, split those into separate lists of transactions
+(one for each byte lane) and supply those to single byte wide versions of 'memoryWb'.
+We combine the responses we obtain and that should behave the same as driveStandard |> splitOnMask |> repeatC (memoryWb (blockRam (C.replicate d256 0))).
+-}
+prop_splitOnMask :: Property
+prop_splitOnMask = property $ do
+  reqs <- forAll $ genData (genWishboneTransfer @8 @4 Range.constantBounded)
+  stallCounts <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  stallsLanes <- forAll $ genVec @4 $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  let
+    reqPairs = L.zip reqs stallCounts
+    eOpts = defExpectOptions{eoSampleMax = 10_000}
+
+    splitReq :: WishboneMasterRequest 8 4 -> Vec 4 (WishboneMasterRequest 8 1)
+    splitReq (Read addr sel) =
+      C.map (Read addr . resize . (sel `shiftR`) . fromIntegral) indicesI
+    splitReq (Write addr sel dat) =
+      C.map
+        ( (\idx -> Write addr (resize $ shiftR sel idx) (resize $ shiftR dat (idx * 8)))
+            . fromIntegral
+        )
+        indicesI
+
+    runLane :: [WishboneMasterRequest 8 1] -> [Int] -> [WishboneS2M 1]
+    runLane laneReqs laneStalls =
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ L.filter hasTerminateFlag
+        $ fmap snd
+        $ WbStd.sample
+          eOpts
+          (driveStandard eOpts (L.zip laneReqs laneStalls))
+          (memoryWb (blockRam (C.replicate d256 0)))
+
+    perLaneReqs = sequenceA $ L.map splitReq reqs
+
+    combine lanes =
+      (emptyWishboneS2M @4)
+        { readData = pack $ fmap (.readData) lanes
+        , acknowledge = C.all (.acknowledge) lanes
+        , err = C.any (.err) lanes
+        }
+
+    (l0, l1, l2, l3) = vecToTuple $ reverse $ zipWith runLane perLaneReqs stallsLanes
+    expected = L.zipWith4 (\s0 s1 s2 s3 -> combine (s0 :> s1 :> s2 :> s3 :> Nil)) l0 l1 l2 l3
+
+    actual =
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ L.filter hasTerminateFlag
+        $ fmap snd
+        $ WbStd.sample
+          eOpts
+          (driveStandard eOpts reqPairs)
+          ( splitOnMask @_ @_ @1 @4
+              |> repeatC (memoryWb (blockRam (C.replicate d256 0)))
+              |> Circuit (\(_, ()) -> (C.repeat (), ()))
+          )
+
+  footnote $ [i| Per lane requests: #{perLaneReqs}|]
+  footnote $ [i| Expected: #{expected}|]
+  footnote $ [i| Actual: #{actual}|]
+  assert (and $ L.zipWith3 eqWishboneS2M reqs actual expected)
 
 tests :: TestTree
 tests =

--- a/clash-protocols/tests/Tests/Protocols/Wishbone.hs
+++ b/clash-protocols/tests/Tests/Protocols/Wishbone.hs
@@ -1,28 +1,32 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 module Tests.Protocols.Wishbone where
 
-import Clash.Prelude as C hiding (not, (&&))
+import Clash.Prelude as C
+
 import Control.DeepSeq (force)
 import Control.Exception (SomeException, evaluate, try)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Either (isLeft)
 import Data.List qualified as L
+import Data.String.Interpolate (i)
 import Hedgehog
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Protocols
-import Protocols.Experimental.Hedgehog (defExpectOptions, eoSampleMax)
+import Protocols.Experimental.Hedgehog (defExpectOptions, eoResetCycles, eoSampleMax)
 import Protocols.Experimental.Wishbone
 import Protocols.Experimental.Wishbone.Standard
 import Protocols.Experimental.Wishbone.Standard.Hedgehog
+import Protocols.Experimental.Wishbone.Standard.Hedgehog qualified as WbStd
 import Test.Tasty
 import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
 import Test.Tasty.Hedgehog.Extra (testProperty)
 import Test.Tasty.TH (testGroupGenerator)
-import Prelude hiding (undefined)
 
 smallInt :: Range Int
 smallInt = Range.linear 0 10
@@ -82,14 +86,14 @@ addrReadIdWbModel Write{} s@WishboneS2M{..} ()
 
 prop_addrReadIdWb_model :: Property
 prop_addrReadIdWb_model =
-  property $
-    withClockResetEnable clockGen resetGen enableGen $
-      wishbonePropWithModel @System @10 @4
-        defExpectOptions{eoSampleMax = 10_000}
-        addrReadIdWbModel
-        addrReadIdWb
-        (genData $ genWishboneTransfer Range.constantBounded)
-        ()
+  property
+    $ withClockResetEnable clockGen resetGen enableGen
+    $ wishbonePropWithModel @System @10 @4
+      defExpectOptions{eoSampleMax = 10_000}
+      addrReadIdWbModel
+      addrReadIdWb
+      (genData $ genWishboneTransfer Range.constantBounded)
+      ()
 
 --
 -- memory element circuit
@@ -111,17 +115,17 @@ memoryWbModel (Read addr sel) s st
       Just x | readData s == x && acknowledge s -> Right st
       Just x
         | otherwise ->
-            Left $
-              "Read from a known address did not yield the same value "
-                <> showX x
-                <> " : "
-                <> show s
+            Left
+              $ "Read from a known address did not yield the same value "
+              <> showX x
+              <> " : "
+              <> show s
       Nothing | acknowledge s && hasX (readData s) == Right def -> Right st
       Nothing
         | otherwise ->
-            Left $
-              "Read from unknown address did no ACK with undefined result : "
-                <> show s
+            Left
+              $ "Read from unknown address did no ACK with undefined result : "
+              <> show s
 memoryWbModel (Write addr sel a) s st
   | sel /= maxBound && err s = Right st
   | sel /= maxBound && not (err s) =
@@ -131,14 +135,14 @@ memoryWbModel (Write addr sel a) s st
 
 prop_memoryWb_model :: Property
 prop_memoryWb_model =
-  property $
-    withClockResetEnable clockGen resetGen enableGen $
-      wishbonePropWithModel @System @8 @4
-        defExpectOptions{eoSampleMax = 10_000}
-        memoryWbModel
-        (memoryWb (blockRam (C.replicate d256 0)))
-        (genData (genWishboneTransfer Range.constantBounded))
-        [] -- initial state
+  property
+    $ withClockResetEnable clockGen resetGen enableGen
+    $ wishbonePropWithModel @System @8 @4
+      defExpectOptions{eoSampleMax = 10_000}
+      memoryWbModel
+      (memoryWb (blockRam (C.replicate d256 0)))
+      (genData (genWishboneTransfer Range.constantBounded))
+      [] -- initial state
 
 --
 -- Helpers
@@ -170,15 +174,15 @@ prop_addrReadId_validator = property $ do
 
   let
     circuitSignalsN =
-      withClockResetEnable @System clockGen resetGen enableGen $
-        let
-          driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
-          addrRead = addrReadIdWb
-         in
-          evaluateUnitCircuit
-            sampleNumber
-            driver
-            (validatorCircuit |> addrRead)
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ let
+            driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
+            addrRead = addrReadIdWb
+           in
+            evaluateUnitCircuit
+              sampleNumber
+              driver
+              (validatorCircuit |> addrRead)
 
   -- force evalution of sampling somehow
   assert (circuitSignalsN == sampleNumber)
@@ -189,15 +193,15 @@ prop_memoryWb_validator = property $ do
 
   let
     circuitSignalsN =
-      withClockResetEnable @System clockGen resetGen enableGen $
-        let
-          driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
-          memory = memoryWb (blockRam (C.replicate d256 0))
-         in
-          evaluateUnitCircuit
-            sampleNumber
-            driver
-            (validatorCircuit |> memory)
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ let
+            driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
+            memory = memoryWb (blockRam (C.replicate d256 0))
+           in
+            evaluateUnitCircuit
+              sampleNumber
+              driver
+              (validatorCircuit |> memory)
 
   -- force evalution of sampling somehow
   assert (circuitSignalsN == sampleNumber)
@@ -212,15 +216,15 @@ prop_addrReadId_validator_lenient = property $ do
 
   let
     circuitSignalsN =
-      withClockResetEnable @System clockGen resetGen enableGen $
-        let
-          driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
-          addrRead = addrReadIdWb
-         in
-          evaluateUnitCircuit
-            sampleNumber
-            driver
-            (validatorCircuitLenient |> addrRead)
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ let
+            driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
+            addrRead = addrReadIdWb
+           in
+            evaluateUnitCircuit
+              sampleNumber
+              driver
+              (validatorCircuitLenient |> addrRead)
 
   -- force evalution of sampling somehow
   assert (circuitSignalsN == sampleNumber)
@@ -231,15 +235,15 @@ prop_memoryWb_validator_lenient = property $ do
 
   let
     circuitSignalsN =
-      withClockResetEnable @System clockGen resetGen enableGen $
-        let
-          driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
-          memory = memoryWb (blockRam (C.replicate d256 0))
-         in
-          evaluateUnitCircuit
-            sampleNumber
-            driver
-            (validatorCircuitLenient |> memory)
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ let
+            driver = driveStandard defExpectOptions{eoSampleMax = 10_000} reqs
+            memory = memoryWb (blockRam (C.replicate d256 0))
+           in
+            evaluateUnitCircuit
+              sampleNumber
+              driver
+              (validatorCircuitLenient |> memory)
 
   -- force evalution of sampling somehow
   assert (circuitSignalsN == sampleNumber)
@@ -251,15 +255,15 @@ prop_specViolation_lenient = property $ do
 
   let
     circuitSignalsN =
-      withClockResetEnable @System clockGen resetGen enableGen $
-        let
-          driver = driveStandard @System @8 @1 defExpectOptions{eoSampleMax = 10_000} reqs
-          invalid = invalidCircuit
-         in
-          evaluateUnitCircuit
-            sampleNumber
-            driver
-            (validatorCircuitLenient |> invalid)
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ let
+            driver = driveStandard @System @8 @1 defExpectOptions{eoSampleMax = 10_000} reqs
+            invalid = invalidCircuit
+           in
+            evaluateUnitCircuit
+              sampleNumber
+              driver
+              (validatorCircuitLenient |> invalid)
 
   -- an ErrorCall is expected, but really *any* exception is expected
   -- from the validator circuit
@@ -287,11 +291,85 @@ prop_specViolation_lenient = property $ do
 sampleNumber :: Int
 sampleNumber = 1000
 
+--
+-- latchResponse
+--
+
+-- | Check whether 'latchResponse' acts as an identity circuit on a transactional level.
+prop_latchResponse_identity :: Property
+prop_latchResponse_identity = property $ do
+  reqs <- forAll $ genData (genWishboneTransfer @8 @4 Range.linearBounded)
+  earlyBusCycle <- forAll Gen.bool
+  driveStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  memStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  let
+    eOpts = defExpectOptions{eoSampleMax = 10_000}
+
+    run ::
+      ((HiddenClockResetEnable System) => Circuit (Wishbone System 'Standard 8 4) ()) ->
+      [WishboneS2M 4]
+    run ckt =
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ L.filter hasTerminateFlag
+        $ fmap snd
+        $ WbStd.sample
+          eOpts
+          (driveStandard eOpts (L.zip reqs driveStalls))
+          ckt
+
+    expected = run (memoryWb (blockRam (C.replicate d256 0)))
+    actual =
+      run
+        ( latchResponse
+            |> stallStandard earlyBusCycle memStalls
+            |> memoryWb (blockRam (C.replicate d256 0))
+        )
+
+  L.length actual === L.length expected
+
+  footnote [i| Expected: #{expected}|]
+  footnote [i| Actual: #{actual}|]
+  assert (and $ L.zipWith3 eqWishboneS2M reqs actual expected)
+
+-- | Check whether 'latchResponse' retains the last response until a new transaction is started.
+prop_latchResponse_retains :: Property
+prop_latchResponse_retains = property $ do
+  reqs <-
+    forAll $ Gen.list (Range.linear 1 300) (genWishboneTransfer @8 @4 Range.linearBounded)
+  earlyBusCycle <- forAll Gen.bool
+  driveStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  memStalls <- forAll $ Gen.list (Range.singleton (L.length reqs)) genSmallInt
+  let
+    eOpts = defExpectOptions{eoResetCycles = 5}
+
+    trace =
+      withClockResetEnable @System clockGen resetGen enableGen
+        $ sampleUnfiltered
+          eOpts
+          (driveStandard eOpts (L.zip reqs driveStalls))
+          ( latchResponse
+              |> stallStandard earlyBusCycle memStalls
+              |> memoryWb (blockRam (C.replicate d256 0))
+          )
+
+    checkCycle (lastReq, latched) (m2s, s2m)
+      | busCycle m2s =
+          ((Just m2s, s2m), True)
+      | Just req <- lastReq =
+          ((lastReq, latched), eqWishboneS2M (m2sToRequest req) latched s2m)
+      | otherwise =
+          ((lastReq, latched), True)
+
+    (_, checks) = L.mapAccumL checkCycle (Nothing, emptyWishboneS2M) trace
+
+  footnoteShow trace
+  assert $ and checks
+
 tests :: TestTree
 tests =
   -- TODO: Move timeout option to hedgehog for better error messages.
   -- TODO: Does not seem to work for combinatorial loops like @let x = x in x@??
-  localOption (mkTimeout 60_000_000 {- 60 seconds -}) $
-    localOption
+  localOption (mkTimeout 60_000_000 {- 60 seconds -})
+    $ localOption
       (HedgehogTestLimit (Just 1000))
       $(testGroupGenerator)


### PR DESCRIPTION
When I tried to apply the previous implementation of `stallStandard` I could not get it working and discovered it is not  used in either `clash-protocols` or `bittide-hardware`.

So I simplified the implementation such that the only thing `stallStandard` does is block the outgoing strobe (and or busCycle) signals to artificially stall the manager.

I managed to use the function on bittide, currently looking into making test infra for it.