### PR TITLE
Remove unnecessary constraint from `delayWishbone`

### DIFF
--- a/clash-protocols/src/Protocols/Experimental/Wishbone/Extra.hs
+++ b/clash-protocols/src/Protocols/Experimental/Wishbone/Extra.hs
@@ -25,7 +25,7 @@ to manager.
 -}
 delayWishbone ::
   forall dom aw n.
-  (HiddenClockResetEnable dom, KnownNat aw, KnownNat n, 1 <= n) =>
+  (HiddenClockResetEnable dom, KnownNat aw, KnownNat n) =>
   Circuit (Wishbone dom 'Standard aw n) (Wishbone dom 'Standard aw n)
 delayWishbone = Circuit go
  where


### PR DESCRIPTION
Turns out, this constraint isn't needed and makes a bunch of downstream code more complex.