### PR TITLE
Make all Nix (shells) buildable

### DIFF
--- a/clash-protocols-base/clash-protocols-base.cabal
+++ b/clash-protocols-base/clash-protocols-base.cabal
@@ -57,7 +57,7 @@ common common-options
 
   default-language: GHC2021
   build-depends:
-    Cabal >=3.12 && <3.17,
+    Cabal >=3.10 && <3.17,
     base >=4.18 && <5,
     clash-prelude >=1.10 && <1.12,
 

--- a/clash-protocols/clash-protocols.cabal
+++ b/clash-protocols/clash-protocols.cabal
@@ -73,7 +73,6 @@ common common-options
 
   default-language: GHC2021
   build-depends:
-    Cabal >=3.12 && <3.17,
     base >=4.18 && <5,
     clash-prelude >=1.10 && <1.12,
     ghc-typelits-extra,
@@ -82,7 +81,9 @@ common common-options
 
 custom-setup
   setup-depends:
-    Cabal >=3.12 && <3.17,
+    -- XXX: Keep Cabal constraint at current minimum, unless this is fixed:
+    -- https://github.com/clash-lang/clash-compiler/pull/2665#issuecomment-1939044550
+    Cabal >=3.10.3.0 && <3.17,
     base >=4.18 && <5,
     cabal-doctest >=1.0.1 && <1.1,
 

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776863546,
-        "narHash": "sha256-qUpyqa7HJYQm1UKG5PahJZ+W8t2EaMOEHDP7yjWoiDY=",
+        "lastModified": 1779814399,
+        "narHash": "sha256-sqYRHf0QoSkVv30BwXk5V7f95E1KINiXj043cRGmyjk=",
         "owner": "clash-lang",
         "repo": "clash-compiler",
-        "rev": "74527b37c83dba39b831fe16233ed665f8154f3f",
+        "rev": "c23378a3c8569d4138515eee68445ffd990dd85a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,9 @@
 {
   "nodes": {
-    "circuit-notation": {
-      "inputs": {
-        "clash-compiler": [
-          "clash-compiler"
-        ],
-        "flake-utils": "flake-utils"
-      },
-      "locked": {
-        "lastModified": 1776956091,
-        "narHash": "sha256-aDt8K/ZTC/fe/KdHjS82IxY3N4Qc6Z/r0JI/ViowOFk=",
-        "owner": "cchalmers",
-        "repo": "circuit-notation",
-        "rev": "4ca9b51256306b10d37355deef5b4a6bd68db796",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cchalmers",
-        "repo": "circuit-notation",
-        "type": "github"
-      }
-    },
     "clash-compiler": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "ghc-tcplugin-api": "ghc-tcplugin-api",
         "ghc-typelits-extra": "ghc-typelits-extra",
         "ghc-typelits-knownnat": "ghc-typelits-knownnat",
@@ -74,31 +53,14 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -195,9 +157,8 @@
     },
     "root": {
       "inputs": {
-        "circuit-notation": "circuit-notation",
         "clash-compiler": "clash-compiler",
-        "flake-utils": "flake-utils_3"
+        "flake-utils": "flake-utils_2"
       }
     },
     "systems": {
@@ -216,21 +177,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
             hs-pkgs
           ) all-overlays;
 
-        minimal-shell = hs-pkgs: hs-pkgs.shellFor {
+        minimal-shell = compiler-version: hs-pkgs: hs-pkgs.shellFor {
           packages = p: [
             p.clash-protocols
             p.clash-protocols-base
@@ -113,16 +113,23 @@
             hs-pkgs.cabal-install
             hs-pkgs.cabal-plan
             hs-pkgs.fourmolu
-            hs-pkgs.cabal-gild
-          ];
+          ]
+          # The cabal-gild in the clash package set requires base >=4.19, which
+          # ghc96* (base-4.18) doesn't provide, so it can't be built there. We
+          # exclude it rather than pin a compatible version, because the last
+          # cabal-gild supporting base-4.18 is 1.5.0.0 (everything from 1.5.0.1
+          # onwards dropped it), which is too old to be worth carrying for ghc96*.
+          ++ clash-compiler.inputs.nixpkgs.lib.optional
+               (!clash-compiler.inputs.nixpkgs.lib.hasPrefix "ghc96" compiler-version)
+               hs-pkgs.cabal-gild;
         };
 
         all-shells = clash-compiler.inputs.nixpkgs.lib.attrsets.concatMapAttrs (name: hs-pkgs: {
             # The difference between the `-minimal` and `-full` is the addition of HLS in the full version
             # This is because HLS is slow to compile and not everyone uses it
             # We default to using the `-minimal` version when `nix develop`ing
-            "${name}-minimal" = minimal-shell hs-pkgs;
-            "${name}-full" = (minimal-shell hs-pkgs).overrideAttrs (fAttr: pAttr: {
+            "${name}-minimal" = minimal-shell name hs-pkgs;
+            "${name}-full" = (minimal-shell name hs-pkgs).overrideAttrs (fAttr: pAttr: {
               nativeBuildInputs = pAttr.nativeBuildInputs ++ [
                 hs-pkgs.haskell-language-server
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -41,19 +41,42 @@
               else
                 {};
 
+            # Each package ships its CHANGELOG.md as a symlink to the repo-root
+            # CHANGELOG.md (../CHANGELOG.md). Nix copies the package directory
+            # without that out-of-root target, so the symlink dangles in the
+            # build sandbox. Cabal >=3.12 (ghc9101+) merely warns about the
+            # unmatched 'extra-doc-files' wildcard, but the Cabal 3.10 shipped
+            # with ghc96*/ghc98* treats it as a fatal error. Replace the
+            # dangling symlink with the real file for those.
+            changelog = ./CHANGELOG.md;
+            # True for ghc96* / ghc98*, which ship Cabal 3.10.
+            uses-cabal-3-10 =
+              clash-compiler.inputs.nixpkgs.lib.hasPrefix "ghc96" compiler-version
+              || clash-compiler.inputs.nixpkgs.lib.hasPrefix "ghc98" compiler-version;
+            fixup-changelog = drv:
+              if uses-cabal-3-10 then
+                drv.overrideAttrs (pAttr: {
+                  postPatch = pAttr.postPatch or "" + ''
+                    rm -f CHANGELOG.md
+                    cp ${changelog} CHANGELOG.md
+                  '';
+                })
+              else
+                drv;
+
             overlay = final: prev: {
               # Append the package set with clash-protocols*
-              clash-protocols = (prev.developPackage {
+              clash-protocols = fixup-changelog ((prev.developPackage {
                 root = ./clash-protocols;
                 overrides = _: _: final;
                 # Remove me when https://github.com/clash-lang/clash-protocols/issues/131
                 # has been solved
                 modifier = drv: drv.overrideAttrs (_: { doCheck = false; });
-              }).overrideAttrs override-attrs;
-              clash-protocols-base = prev.developPackage {
+              }).overrideAttrs override-attrs);
+              clash-protocols-base = fixup-changelog (prev.developPackage {
                 root = ./clash-protocols-base;
                 overrides = _: _: final;
-              };
+              });
             } // circuit-notation.overlays.${system}.${compiler-version} final prev;
           in
             { name = compiler-version; value = overlay; }

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,8 @@
   description = "A flake for the clash-protocols and clash-protocols-base";
   inputs = {
     clash-compiler.url = "github:clash-lang/clash-compiler";
-    circuit-notation = {
-      url = "github:cchalmers/circuit-notation";
-      inputs.clash-compiler.follows = "clash-compiler";
-    };
   };
-  outputs = { self, flake-utils, clash-compiler, circuit-notation, ... }:
+  outputs = { self, flake-utils, clash-compiler, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         # The package to expose as 'default'
@@ -65,6 +61,14 @@
                 drv;
 
             overlay = final: prev: {
+              # The clash package set ships circuit-notation 0.1.0.0, but
+              # clash-protocols requires >=0.2. Pull 0.2.0.0 from Hackage.
+              circuit-notation = prev.callHackageDirect {
+                pkg = "circuit-notation";
+                ver = "0.2.0.0";
+                sha256 = "sha256-tdM3spbXjQvcnBrmVS0i0tLqoHJ/pnniSOy3eTEZKuw=";
+              } {};
+
               # Append the package set with clash-protocols*
               clash-protocols = fixup-changelog ((prev.developPackage {
                 root = ./clash-protocols;
@@ -77,7 +81,7 @@
                 root = ./clash-protocols-base;
                 overrides = _: _: final;
               });
-            } // circuit-notation.overlays.${system}.${compiler-version} final prev;
+            };
           in
             { name = compiler-version; value = overlay; }
           ) supported-versions);
@@ -141,10 +145,6 @@
         # A devShell for each supported version
         #
         # These can be invoked using `nix develop .#ghc9101-minimal`
-        #
-        # Please do note that if you work with Nix, you need to remove the `cabal.project` file at
-        # the root of the directory! Cabal prioritizes local source overrides over Nix, which causes
-        # the circuit-notation package to incorrectly fetched from Hackage rather than Nix.
         devShells = all-shells // { default = all-shells."${default-version}-minimal"; };
 
         # The default directly refers to the default package of the default ghc version of this flake


### PR DESCRIPTION
This doesn't add it to CI yet, I'll rebase https://github.com/clash-lang/clash-protocols/pull/167 on top of this.

Two opinionated fixes:

* I'm copying CHANGELOG.md in the Nix expression. This hack should disappear over time, once we drop support for older GHCs/Cabals.
* I couldn't get `cabal-gild` to work for the GHC 9.6.7. I thought about overriding it to another version, but that would mean different formatters in different shells. Instead I just disabled it for the old GHC.